### PR TITLE
Implement pass-through callbacks (fix for #11)

### DIFF
--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -80,6 +80,9 @@ abstract class AbstractRequest implements ProvidesRequestData
 	/** @var array|callable[] */
 	private $failureCallbacks = [];
 
+	/** @var array|callable[] */
+	private $passThroughCallbacks = [];
+
 	public function __construct( string $scriptFilename, string $content )
 	{
 		$this->scriptFilename = $scriptFilename;
@@ -262,5 +265,15 @@ abstract class AbstractRequest implements ProvidesRequestData
 	public function addFailureCallbacks( callable  ...$callbacks )
 	{
 		$this->failureCallbacks = array_merge( $this->failureCallbacks, $callbacks );
+	}
+
+	public function getPassThroughCallbacks() : array
+	{
+		return $this->passThroughCallbacks;
+	}
+
+	public function addPassThroughCallbacks( callable ...$callbacks )
+	{
+		$this->passThroughCallbacks = array_merge( $this->passThroughCallbacks, $callbacks );
 	}
 }

--- a/tests/Integration/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocketTest.php
@@ -291,4 +291,38 @@ final class UnixDomainSocketTest extends TestCase
 
 		$this->expectOutputString( 'unit' );
 	}
+
+	public function testCanReceivePacketInPassThroughCallback()
+	{
+		$connection = new UnixDomainSocket( '/var/run/php-uds.sock' );
+		$client     = new Client( $connection );
+		$data       = [ 'test-key' => str_repeat( 'test-first-key', 5000 ), 'test-second-key' => 'test-second-key', 'test-third-key' => str_repeat( 'test-third-key', 5000 ) ];
+		$content    = http_build_query( $data );
+		$request    = new PostRequest( __DIR__ . '/Workers/worker.php', $content );
+
+		$unitTest = $this;
+
+		$request->addPassThroughCallbacks(
+			function ( $packet ) use ( $unitTest, $data )
+			{
+				static $pass = 0;
+				if ( $pass === 0 )
+				{
+					/* The first key is large enough to be dumped immediately with all headers */
+					$unitTest->assertContains( $data['test-key'], $packet );
+				}
+				elseif ( $pass === 1 )
+				{
+					/* The second key is too small to be dumped, hence the second packet will show both second AND third keys */
+					$unitTest->assertNotContains( $data['test-key'], $packet );
+					$unitTest->assertContains( $data['test-second-key'], $packet );
+					$unitTest->assertContains( $data['test-third-key'], $packet );
+				}
+				$pass++;
+			}
+		);
+
+		$client->sendAsyncRequest( $request );
+		$client->waitForResponses();
+	}
 }

--- a/tests/Integration/Workers/worker.php
+++ b/tests/Integration/Workers/worker.php
@@ -26,3 +26,11 @@ header( 'X-Custom: Header' );
 usleep( 50000 );
 echo $_REQUEST['test-key'];
 
+if (isset( $_REQUEST['test-second-key']) )
+{
+	echo $_REQUEST['test-second-key'];
+}
+if (isset( $_REQUEST['test-third-key']) )
+{
+	echo $_REQUEST['test-third-key'];
+}


### PR DESCRIPTION
Implemented in 1.x-stable only, I don't have PHP 7.1 to test the branch on master. Fixes #11.

Added 2 tests to check if it worked well.

Must add that PHP-FPM will return the echo'ed text as soon as it goes over the limit of `output_buffering`.