### PR TITLE
fix travis build: use phpenv version in php-fpm include path (#21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_script:
  - echo $(phpenv version-name)
  - sudo mkdir -pm 0777 /var/run
  - sudo usermod -a -G travis www-data
- - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+ - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf
+ - echo -e "[global]\ninclude=/home/travis/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/*.conf" > ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
  - sudo cp env/php-fpm/$(phpenv version-name)/network-socket.pool.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/network-socket.pool.conf
  - sudo cp env/php-fpm/$(phpenv version-name)/unix-domain-socket.pool.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/unix-domain-socket.pool.conf
  - sudo cp env/php-fpm/$(phpenv version-name)/restricted-unix-domain-socket.pool.conf ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/restricted-unix-domain-socket.pool.conf


### PR DESCRIPTION
Fixes #21 

## Proposed Changes

- generate our own `php-fpm.conf` using the path from `phpenv version-name`
- purge the default `www.conf` file provided by `phpenv`

## Further comments

For some PHP versions, the version used in the php-fpm.conf.default
include path doesn't match the output of 'phpenv version-name'.

For example, as of this writing, with the 7.1 version, the config file
references ~/.phpenv/versions/7.1.11, but 'phpenv version-name' returns
"7.1", which means the php-fpm service does not reference the config
files that are copied in during the build setup.

Now we write our own php-fpm.conf which uses the path from
'phpenv version-name', which guarantees our config files are used.

In addition, we purge the 'www.conf' file which is provided by phpenv
and interferes with our configurations (duplicate listening port,
unknown group, etc.).