### PR TITLE
Research/use idle sockets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ shared-unit-tests: &shared-unit-tests
 
     - run:
         name: Run unit tests
-        command: vendor/bin/phpunit$PHPUNIT_VERSION.phar -c build --testsuite Unit --log-junit build/logs/junit/junit.xml --coverage-html build/logs/coverage --coverage-clover=coverage.xml
+        command: php -d auto_prepend_file=build/xdebug-filter.php vendor/bin/phpunit$PHPUNIT_VERSION.phar -c build --testsuite Unit --log-junit build/logs/junit/junit.xml --coverage-html build/logs/coverage --coverage-clover=coverage.xml
 
     - run:
         name: Upload code coverage to codecov.io
@@ -152,7 +152,7 @@ shared-integration-tests: &shared-integration-tests
 
     - run:
         name: Run integration tests
-        command: vendor/bin/phpunit$PHPUNIT_VERSION.phar -c build --testsuite Integration --log-junit build/logs/junit/junit.xml
+        command: php -d auto_prepend_file=build/xdebug-filter.php vendor/bin/phpunit$PHPUNIT_VERSION.phar -c build --testsuite Integration --log-junit build/logs/junit/junit.xml
 
     - store_test_results:
         path: build/logs/junit

--- a/.docker/php/7.1/Dockerfile
+++ b/.docker/php/7.1/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.1-fpm-alpine
 ENV PHP_CONF_DIR=/usr/local/etc
 RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug-2.7.1 \
     && docker-php-ext-enable xdebug \
     && apk del $PHPIZE_DEPS
 COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf

--- a/.docker/php/7.2/Dockerfile
+++ b/.docker/php/7.2/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.2-fpm-alpine
 ENV PHP_CONF_DIR=/usr/local/etc
 RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug-2.7.1 \
     && docker-php-ext-enable xdebug \
     && apk del $PHPIZE_DEPS
 COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf

--- a/.docker/php/7.3/Dockerfile
+++ b/.docker/php/7.3/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3-fpm-alpine
 ENV PHP_CONF_DIR=/usr/local/etc
 RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.0 \
+    && pecl install xdebug-2.7.1 \
     && docker-php-ext-enable xdebug \
     && apk del $PHPIZE_DEPS
 COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf

--- a/.docker/php/network-socket.pool.conf
+++ b/.docker/php/network-socket.pool.conf
@@ -2,7 +2,7 @@
 [network]
 user = www-data
 group = www-data
-listen = 127.0.0.1:9001
+listen = 0.0.0.0:9001
 listen.owner = www-data
 listen.group = www-data
 pm = dynamic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [2.7.0] - YYYY-MM-DD
+
+### Added
+
+* Re-using of idle sockets - [#33]
+
 ## [2.6.0] - 2019-04-02
 
 ### Added
@@ -180,6 +186,7 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
  * Getters/Setters for connect timeout, read/write timeout, keep alive, socket persistence from `Client` (now part of the socket connection)
  * Method `Client->getValues()`
 
+[2.7.0]: https://github.com/hollodotme/fast-cgi-client/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/hollodotme/fast-cgi-client/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/hollodotme/fast-cgi-client/compare/v2.4.3...v2.5.0
 [2.4.3]: https://github.com/hollodotme/fast-cgi-client/compare/v2.4.2...v2.4.3
@@ -204,3 +211,4 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
 [#20]: https://github.com/hollodotme/fast-cgi-client/issues/20
 [#26]: https://github.com/hollodotme/fast-cgi-client/issues/26
 [#27]: https://github.com/hollodotme/fast-cgi-client/issues/27
+[#33]: https://github.com/hollodotme/fast-cgi-client/pull/33

--- a/bin/persistant.php
+++ b/bin/persistant.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Bin;
+
+use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\Requests\PostRequest;
+use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use function error_reporting;
+use function ini_set;
+
+error_reporting( E_ALL );
+ini_set( 'display_errors', 'On' );
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$connection = new UnixDomainSocket( '/var/run/php-uds.sock' );
+$client     = new Client( $connection );
+
+$workerPath = __DIR__ . '/exampleWorker.php';
+
+$request = new PostRequest( $workerPath, 'test=persistant' );
+
+for ( $i = 1; $i < 10; $i++ )
+{
+	echo "{$i}. Request\n";
+	$response = $client->sendRequest( $request );
+	printf( "Socket-ID: %s\n%s\n\n", $response->getRequestId(), $response->getOutput() );
+}

--- a/build/phpunit.xml
+++ b/build/phpunit.xml
@@ -1,22 +1,30 @@
 <phpunit
-	bootstrap="../tests/bootstrap.php"
-	verbose="true"
-	beStrictAboutOutputDuringTests="true"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true">
-	<testsuites>
+    bootstrap="../tests/bootstrap.php"
+    verbose="true"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true">
+  <php>
+    <env name="network-socket-host" value="127.0.0.1"/>
+    <env name="network-socket-port" value="9001"/>
+    <env name="unix-domain-socket" value="/var/run/php-uds.sock"/>
+    <env name="restricted-unix-domain-socket" value="/var/run/php-ruds.sock"/>
+    <env name="non-existing-unix-domain-socket" value="/tmp/not/existing.sock"/>
+    <env name="invalid-unix-domain-socket" value="/Fixtures/test.sock"/>
+  </php>
+  <testsuites>
     <testsuite name="Unit">
-			<directory suffix="Test.php">../tests/Unit</directory>
-		</testsuite>
+      <directory suffix="Test.php">../tests/Unit</directory>
+    </testsuite>
     <testsuite name="Integration">
-			<directory suffix="Test.php">../tests/Integration</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">../src</directory>
-		</whitelist>
-	</filter>
+      <directory suffix="Test.php">../tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">../src</directory>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/build/xdebug-filter.php
+++ b/build/xdebug-filter.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+if ( !function_exists( 'xdebug_set_filter' ) )
+{
+	return;
+}
+
+/** @noinspection PhpUndefinedFunctionInspection */
+/** @noinspection PhpUndefinedConstantInspection */
+xdebug_set_filter(
+	XDEBUG_FILTER_CODE_COVERAGE,
+	XDEBUG_PATH_WHITELIST,
+	[dirname( __DIR__ ) . '/src']
+);

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,55 @@
 {
-	"name": "hollodotme/fast-cgi-client",
-	"description": "A PHP fast CGI client to send requests (a)synchronously to PHP-FPM.",
-	"keywords": [
-		"fastcgi",
-		"php-fpm",
-		"socket"
-	],
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Holger Woltersdorf",
-			"email": "hw@hollo.me"
-		}
-	],
-	"bin": [
-		"bin/fcgiget"
-	],
-	"autoload": {
-		"psr-4": {
-			"hollodotme\\FastCGI\\": "src/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"hollodotme\\FastCGI\\Tests\\": "tests/"
-		}
-	},
-	"require": {
-		"php": ">=7.1"
-	},
-	"require-dev": {
-		"tm/tooly-composer-script": "^1.0"
-	},
-	"scripts": {
-		"post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
-		"post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
-	},
-	"extra": {
-		"tools": {
-			"phpunit7": {
-				"url": "https://phar.phpunit.de/phpunit-7.phar",
-				"only-dev": true
-			},
-			"phpunit8": {
-				"url": "https://phar.phpunit.de/phpunit-8.phar",
-				"only-dev": true
-			}
-		}
-	}
+  "name": "hollodotme/fast-cgi-client",
+  "description": "A PHP fast CGI client to send requests (a)synchronously to PHP-FPM.",
+  "keywords": [
+    "fastcgi",
+    "php-fpm",
+    "socket"
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Holger Woltersdorf",
+      "email": "hw@hollo.me"
+    }
+  ],
+  "bin": [
+    "bin/fcgiget"
+  ],
+  "autoload": {
+    "psr-4": {
+      "hollodotme\\FastCGI\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "hollodotme\\FastCGI\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": ">=7.1"
+  },
+  "require-dev": {
+    "tm/tooly-composer-script": "^1.0"
+  },
+  "scripts": {
+    "post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
+    "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
+  },
+  "extra": {
+    "tools": {
+      "phpunit7": {
+        "url": "https://phar.phpunit.de/phpunit-7.phar",
+        "replace": true,
+        "only-dev": true
+      },
+      "phpunit8": {
+        "url": "https://phar.phpunit.de/phpunit-8.phar",
+        "replace": true,
+        "only-dev": true
+      }
+    }
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     container_name: fcc_composer
     working_dir: /repo
     restart: "no"
+    command: "update -o -v"
     networks:
       - fcc_network
     volumes:
@@ -49,6 +50,7 @@ services:
     container_name: fcc_phpstan
     working_dir: /repo
     restart: "no"
+    command: "analyze --level max src/"
     networks:
       - fcc_network
     volumes:

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,8 +36,9 @@ use hollodotme\FastCGI\Interfaces\EncodesNameValuePair;
 use hollodotme\FastCGI\Interfaces\EncodesPacket;
 use hollodotme\FastCGI\Interfaces\ProvidesRequestData;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\Sockets\Socket;
+use hollodotme\FastCGI\Sockets\SocketCollection;
 use Throwable;
-use function array_keys;
 use function count;
 use function stream_select;
 
@@ -46,7 +47,7 @@ class Client
 	/** @var ConfiguresSocketConnection */
 	private $connection;
 
-	/** @var array|Socket[] */
+	/** @var SocketCollection */
 	private $sockets;
 
 	/** @var EncodesPacket */
@@ -63,7 +64,7 @@ class Client
 		$this->connection           = $connection;
 		$this->packetEncoder        = new PacketEncoder();
 		$this->nameValuePairEncoder = new NameValuePairEncoder();
-		$this->sockets              = [];
+		$this->sockets              = new SocketCollection();
 	}
 
 	/**
@@ -95,7 +96,7 @@ class Client
 	 */
 	public function sendAsyncRequest( ProvidesRequestData $request ) : int
 	{
-		$socket = $this->getIdleSocket();
+		$socket = $this->sockets->getIdleSocket();
 
 		if ( null !== $socket )
 		{
@@ -104,41 +105,15 @@ class Client
 			return $socket->getId();
 		}
 
-		for ( $i = 0; $i < 10; $i++ )
-		{
-			$socket = new Socket( $this->connection, $this->packetEncoder, $this->nameValuePairEncoder );
+		$socket = $this->sockets->new(
+			$this->connection,
+			$this->packetEncoder,
+			$this->nameValuePairEncoder
+		);
 
-			if ( isset( $this->sockets[ $socket->getId() ] ) )
-			{
-				continue;
-			}
+		$socket->sendRequest( $request );
 
-			$this->sockets[ $socket->getId() ] = $socket;
-
-			$socket->sendRequest( $request );
-
-			return $socket->getId();
-		}
-
-		throw new WriteFailedException( 'Could not allocate a new request ID' );
-	}
-
-	private function getIdleSocket() : ?Socket
-	{
-		if ( [] === $this->sockets )
-		{
-			return null;
-		}
-
-		foreach ( $this->sockets as $socket )
-		{
-			if ( $socket->isIdle() )
-			{
-				return $socket;
-			}
-		}
-
-		return null;
+		return $socket->getId();
 	}
 
 	/**
@@ -150,33 +125,7 @@ class Client
 	 */
 	public function readResponse( int $requestId, ?int $timeoutMs = null ) : ProvidesResponseData
 	{
-		return $this->getSocketWithId( $requestId )->fetchResponse( $timeoutMs );
-	}
-
-	/**
-	 * @param int $requestId
-	 *
-	 * @return Socket
-	 * @throws ReadFailedException
-	 */
-	private function getSocketWithId( int $requestId ) : Socket
-	{
-		$this->guardSocketExists( $requestId );
-
-		return $this->sockets[ $requestId ];
-	}
-
-	/**
-	 * @param int $requestId
-	 *
-	 * @throws ReadFailedException
-	 */
-	private function guardSocketExists( int $requestId ) : void
-	{
-		if ( !isset( $this->sockets[ $requestId ] ) )
-		{
-			throw new ReadFailedException( 'Socket not found for request ID: ' . $requestId );
-		}
+		return $this->sockets->getById( $requestId )->fetchResponse( $timeoutMs );
 	}
 
 	/**
@@ -187,7 +136,7 @@ class Client
 	 */
 	public function waitForResponse( int $requestId, ?int $timeoutMs = null ) : void
 	{
-		$socket = $this->getSocketWithId( $requestId );
+		$socket = $this->sockets->getById( $requestId );
 
 		while ( true )
 		{
@@ -207,7 +156,7 @@ class Client
 	 */
 	public function waitForResponses( ?int $timeoutMs = null ) : void
 	{
-		if ( count( $this->sockets ) === 0 )
+		if ( $this->sockets->isEmpty() )
 		{
 			throw new ReadFailedException( 'No pending requests found.' );
 		}
@@ -244,7 +193,7 @@ class Client
 	 */
 	public function hasUnhandledResponses() : bool
 	{
-		return (count( $this->sockets ) > 0);
+		return $this->sockets->hasBusySockets();
 	}
 
 	/**
@@ -255,7 +204,7 @@ class Client
 	{
 		foreach ( $this->getRequestIdsHavingResponse() as $requestId )
 		{
-			yield $this->getSocketWithId( $requestId );
+			yield $this->sockets->getById( $requestId );
 		}
 	}
 
@@ -267,30 +216,26 @@ class Client
 	 */
 	public function hasResponse( int $requestId ) : bool
 	{
-		return $this->getSocketWithId( $requestId )->hasResponse();
+		return $this->sockets->getById( $requestId )->hasResponse();
 	}
 
 	/**
 	 * @return array
+	 * @throws ReadFailedException
 	 */
 	public function getRequestIdsHavingResponse() : array
 	{
-		if ( count( $this->sockets ) === 0 )
+		if ( $this->sockets->isEmpty() )
 		{
 			return [];
 		}
 
-		$resources = [];
-		$writes    = $excepts = null;
+		$reads  = $this->sockets->collectResources();
+		$writes = $excepts = null;
 
-		foreach ( $this->sockets as $socket )
-		{
-			$socket->collectResource( $resources );
-		}
+		stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
 
-		stream_select( $resources, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
-
-		return array_keys( $resources );
+		return $this->sockets->getSocketIdsByResources( $reads );
 	}
 
 	/**
@@ -305,9 +250,7 @@ class Client
 		{
 			try
 			{
-				$socket = $this->getSocketWithId( $requestId );
-
-				yield $socket->fetchResponse( $timeoutMs );
+				yield $this->sockets->getById( $requestId )->fetchResponse( $timeoutMs );
 			}
 			catch ( Throwable $e )
 			{
@@ -319,6 +262,7 @@ class Client
 	 * @param int|null $timeoutMs
 	 *
 	 * @return Generator|ProvidesResponseData[]
+	 * @throws ReadFailedException
 	 */
 	public function readReadyResponses( ?int $timeoutMs = null ) : Generator
 	{
@@ -338,9 +282,10 @@ class Client
 	 */
 	public function handleResponse( int $requestId, ?int $timeoutMs = null ) : void
 	{
-		$socket = $this->getSocketWithId( $requestId );
-
-		$this->fetchResponseAndNotifyCallback( $socket, $timeoutMs );
+		$this->fetchResponseAndNotifyCallback(
+			$this->sockets->getById( $requestId ),
+			$timeoutMs
+		);
 	}
 
 	/**

--- a/src/Client.php
+++ b/src/Client.php
@@ -104,8 +104,6 @@ class Client
 			return $socket->getId();
 		}
 
-		echo "Creating new socket...\n";
-
 		for ( $i = 0; $i < 10; $i++ )
 		{
 			$socket = new Socket( $this->connection, $this->packetEncoder, $this->nameValuePairEncoder );

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -124,7 +124,7 @@ final class Socket
 	/** @var float */
 	private $startTime;
 
-	/** @var ProvidesResponseData */
+	/** @var null|ProvidesResponseData */
 	private $response;
 
 	/** @var int */

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -413,28 +413,21 @@ final class Socket
 		}
 		while ( null !== $packet );
 
-		try
-		{
-			$this->handleNullPacket( $packet );
-			$character = (string)$packet['content']{4};
-			$this->guardRequestCompleted( ord( $character ) );
+		$this->handleNullPacket( $packet );
+		$character = (string)$packet['content']{4};
+		$this->guardRequestCompleted( ord( $character ) );
 
-			$this->response = new Response(
-				$this->id,
-				$output,
-				$error,
-				microtime( true ) - $this->startTime
-			);
+		$this->response = new Response(
+			$this->id,
+			$output,
+			$error,
+			microtime( true ) - $this->startTime
+		);
 
-			# Set socket to idle again
-			$this->status = self::SOCK_STATE_IDLE;
+		# Set socket to idle again
+		$this->status = self::SOCK_STATE_IDLE;
 
-			return $this->response;
-		}
-		catch ( WriteFailedException | ReadFailedException $e )
-		{
-			throw $e;
-		}
+		return $this->response;
 	}
 
 	private function readPacket() : ?array

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -220,7 +220,12 @@ final class Socket
 			return true;
 		}
 
-		$metaData = stream_get_meta_data( $this->resource );
+		$metaData = @stream_get_meta_data( $this->resource );
+
+		if ( false === $metaData )
+		{
+			return false;
+		}
 
 		return !($metaData['timed_out'] || $metaData['unread_bytes'] || $metaData['eof']);
 	}

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -55,10 +55,6 @@ use function stream_socket_client;
 use function strlen;
 use function substr;
 
-/**
- * Class Socket
- * @package hollodotme\FastCGI
- */
 final class Socket
 {
 	private const BEGIN_REQUEST        = 1;

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -169,7 +169,7 @@ final class Socket
 	 */
 	public function sendRequest( ProvidesRequestData $request ) : void
 	{
-		$this->guardSocketIsIdle();
+		$this->guardSocketIsUsable();
 
 		$this->response = null;
 
@@ -190,9 +190,9 @@ final class Socket
 	/**
 	 * @throws ConnectException
 	 */
-	private function guardSocketIsIdle() : void
+	private function guardSocketIsUsable() : void
 	{
-		if ( !$this->isIdle() )
+		if ( !$this->isIdle() || !$this->isUsable() )
 		{
 			throw new ConnectException( 'Trying to connect to a socket that is not idle.' );
 		}
@@ -200,14 +200,24 @@ final class Socket
 
 	public function isIdle() : bool
 	{
-		if ( !is_resource( $this->resource ) )
+		if ( self::SOCK_STATE_INIT === $this->status )
 		{
 			return true;
 		}
 
-		if ( self::SOCK_STATE_IDLE !== $this->status )
+		if ( self::SOCK_STATE_IDLE === $this->status )
 		{
-			return false;
+			return true;
+		}
+
+		return false;
+	}
+
+	public function isUsable() : bool
+	{
+		if ( null === $this->resource )
+		{
+			return true;
 		}
 
 		$metaData = stream_get_meta_data( $this->resource );

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -220,6 +220,7 @@ final class Socket
 			return true;
 		}
 
+		/** @var false|array $metaData */
 		$metaData = @stream_get_meta_data( $this->resource );
 
 		if ( false === $metaData )

--- a/src/Sockets/SocketCollection.php
+++ b/src/Sockets/SocketCollection.php
@@ -130,10 +130,18 @@ final class SocketCollection implements Countable
 
 		foreach ( $this->sockets as $socket )
 		{
-			if ( $socket->isIdle() )
+			if ( !$socket->isIdle() )
 			{
-				return $socket;
+				continue;
 			}
+
+			if ( !$socket->isUsable() )
+			{
+				$this->remove( $socket->getId() );
+				continue;
+			}
+
+			return $socket;
 		}
 
 		return null;

--- a/src/Sockets/SocketCollection.php
+++ b/src/Sockets/SocketCollection.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Sockets;
+
+use Countable;
+use Exception;
+use hollodotme\FastCGI\Exceptions\ReadFailedException;
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
+use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
+use hollodotme\FastCGI\Interfaces\EncodesNameValuePair;
+use hollodotme\FastCGI\Interfaces\EncodesPacket;
+use function array_search;
+use function count;
+
+final class SocketCollection implements Countable
+{
+	/** @var Socket[] */
+	private $sockets = [];
+
+	/**
+	 * @param ConfiguresSocketConnection $connection
+	 * @param EncodesPacket              $packetEncoder
+	 * @param EncodesNameValuePair       $nameValuePairEncoder
+	 *
+	 * @return Socket
+	 * @throws Exception
+	 * @throws WriteFailedException
+	 */
+	public function new(
+		ConfiguresSocketConnection $connection,
+		EncodesPacket $packetEncoder,
+		EncodesNameValuePair $nameValuePairEncoder
+	) : Socket
+	{
+		for ( $i = 0; $i < 10; $i++ )
+		{
+			$socket = new Socket( $connection, $packetEncoder, $nameValuePairEncoder );
+
+			if ( $this->exists( $socket->getId() ) )
+			{
+				continue;
+			}
+
+			$this->add( $socket );
+
+			return $socket;
+		}
+
+		throw new WriteFailedException( 'Could not allocate a new request ID' );
+	}
+
+	public function add( Socket $socket ) : void
+	{
+		$this->sockets[ $socket->getId() ] = $socket;
+	}
+
+	/**
+	 * @param int $socketId
+	 *
+	 * @return Socket
+	 * @throws ReadFailedException
+	 */
+	public function getById( int $socketId ) : Socket
+	{
+		$this->guardSocketExists( $socketId );
+
+		return $this->sockets[ $socketId ];
+	}
+
+	/**
+	 * @param array $resources
+	 *
+	 * @return array
+	 * @throws ReadFailedException
+	 */
+	public function getSocketIdsByResources( array $resources ) : array
+	{
+		$socketIds = [];
+
+		foreach ( $resources as $resource )
+		{
+			$socketIds[] = $this->getByResource( $resource )->getId();
+		}
+
+		return $socketIds;
+	}
+
+	/**
+	 * @param resource $resource
+	 *
+	 * @return Socket
+	 * @throws ReadFailedException
+	 */
+	public function getByResource( $resource ) : Socket
+	{
+		$socketId = array_search( $resource, $this->collectResources(), true );
+
+		if ( false === $socketId )
+		{
+			throw new ReadFailedException( 'Socket not found for request ID: ' . $socketId );
+		}
+
+		return $this->sockets[ $socketId ];
+	}
+
+	/**
+	 * @param int $socketId
+	 *
+	 * @throws ReadFailedException
+	 */
+	private function guardSocketExists( int $socketId ) : void
+	{
+		if ( !$this->exists( $socketId ) )
+		{
+			throw new ReadFailedException( 'Socket not found for request ID: ' . $socketId );
+		}
+	}
+
+	private function exists( int $socketId ) : bool
+	{
+		return isset( $this->sockets[ $socketId ] );
+	}
+
+	public function remove( int $socketId ) : void
+	{
+		unset( $this->sockets[ $socketId ] );
+	}
+
+	public function getIdleSocket() : ?Socket
+	{
+		if ( $this->isEmpty() )
+		{
+			return null;
+		}
+
+		foreach ( $this->sockets as $socket )
+		{
+			if ( $socket->isIdle() )
+			{
+				return $socket;
+			}
+		}
+
+		return null;
+	}
+
+	public function hasBusySockets() : bool
+	{
+		if ( $this->isEmpty() )
+		{
+			return false;
+		}
+
+		foreach ( $this->sockets as $socket )
+		{
+			if ( $socket->isBusy() )
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public function collectResources() : array
+	{
+		$resources = [];
+
+		foreach ( $this->sockets as $socket )
+		{
+			$socket->collectResource( $resources );
+		}
+
+		return $resources;
+	}
+
+	public function count() : int
+	{
+		return count( $this->sockets );
+	}
+
+	public function isEmpty() : bool
+	{
+		return [] === $this->sockets;
+	}
+}

--- a/src/Sockets/SocketCollection.php
+++ b/src/Sockets/SocketCollection.php
@@ -41,17 +41,12 @@ final class SocketCollection implements Countable
 				continue;
 			}
 
-			$this->add( $socket );
+			$this->sockets[ $socket->getId() ] = $socket;
 
 			return $socket;
 		}
 
 		throw new WriteFailedException( 'Could not allocate a new request ID' );
-	}
-
-	public function add( Socket $socket ) : void
-	{
-		$this->sockets[ $socket->getId() ] = $socket;
 	}
 
 	/**
@@ -97,7 +92,7 @@ final class SocketCollection implements Countable
 
 		if ( false === $socketId )
 		{
-			throw new ReadFailedException( 'Socket not found for request ID: ' . $socketId );
+			throw new ReadFailedException( 'Socket not found for resource' );
 		}
 
 		return $this->sockets[ $socketId ];

--- a/tests/Integration/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocketTest.php
@@ -256,7 +256,7 @@ final class NetworkSocketTest extends TestCase
 			$this->getNetworkSocketHost(),
 			$this->getNetworkSocketPort(),
 			Defaults::CONNECT_TIMEOUT,
-			1000
+			100
 		);
 		$client     = new Client( $connection );
 		$content    = http_build_query( ['test-key' => 'unit'] );
@@ -266,7 +266,7 @@ final class NetworkSocketTest extends TestCase
 
 		$this->assertSame( 'unit - 0', $response->getBody() );
 
-		$content = http_build_query( ['sleep' => 2, 'test-key' => 'unit'] );
+		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( __DIR__ . '/Workers/sleepWorker.php', $content );
 
 		$this->expectException( TimedoutException::class );

--- a/tests/Integration/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocketTest.php
@@ -651,4 +651,29 @@ final class NetworkSocketTest extends TestCase
 
 		$this->assertRegExp( $expectedError, $response->getError() );
 	}
+
+	/**
+	 * @throws ConnectException
+	 * @throws ExpectationFailedException
+	 * @throws Throwable
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 * @throws InvalidArgumentException
+	 */
+	public function testSuccessiveRequestsShouldUseSameSocket() : void
+	{
+		$request = new GetRequest( __DIR__ . '/Workers/sleepWorker.php', '' );
+
+		$requestId = $this->client->sendRequest( $request )->getRequestId();
+
+		$requestIds = [];
+		for ( $i = 0; $i < 5; $i++ )
+		{
+			$requestIds[] = $this->client->sendRequest( $request )->getRequestId();
+		}
+
+		$expectedRequestIds = [$requestId, $requestId, $requestId, $requestId, $requestId];
+
+		$this->assertSame( $expectedRequestIds, $requestIds );
+	}
 }

--- a/tests/Integration/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocketTest.php
@@ -34,6 +34,7 @@ use hollodotme\FastCGI\Requests\GetRequest;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\Defaults;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
@@ -43,12 +44,14 @@ use Throwable;
 
 final class NetworkSocketTest extends TestCase
 {
+	use SocketDataProviding;
+
 	/** @var Client */
 	private $client;
 
 	protected function setUp() : void
 	{
-		$connection   = new NetworkSocket( '127.0.0.1', 9001 );
+		$connection   = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 		$this->client = new Client( $connection );
 	}
 
@@ -114,6 +117,7 @@ final class NetworkSocketTest extends TestCase
 		$response = $this->client->sendRequest( $request );
 
 		$this->assertEquals( $expectedResponse, $response->getRawResponse() );
+		$this->assertEquals( $expectedResponse, $response->getOutput() );
 		$this->assertSame( 'unit', $response->getBody() );
 		$this->assertGreaterThan( 0, $response->getDuration() );
 
@@ -248,7 +252,12 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testReadingSyncResponseCanTimeOut() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9000, Defaults::CONNECT_TIMEOUT, 1000 );
+		$connection = new NetworkSocket(
+			$this->getNetworkSocketHost(),
+			$this->getNetworkSocketPort(),
+			Defaults::CONNECT_TIMEOUT,
+			1000
+		);
 		$client     = new Client( $connection );
 		$content    = http_build_query( ['test-key' => 'unit'] );
 		$request    = new PostRequest( __DIR__ . '/Workers/sleepWorker.php', $content );

--- a/tests/Integration/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocketTest.php
@@ -308,6 +308,7 @@ final class NetworkSocketTest extends TestCase
 	 * @throws ConnectException
 	 * @throws TimedoutException
 	 * @throws WriteFailedException
+	 * @throws ReadFailedException
 	 */
 	public function testCanReadReadyResponses() : void
 	{

--- a/tests/Integration/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocketTest.php
@@ -175,7 +175,7 @@ final class UnixDomainSocketTest extends TestCase
 		);
 
 		$request->addFailureCallbacks(
-			function ( Throwable $throwable ) use ( $unitTest )
+			static function ( Throwable $throwable ) use ( $unitTest )
 			{
 				$unitTest->assertInstanceOf( RuntimeException::class, $throwable );
 				$unitTest->assertSame( 'Response callback threw exception.', $throwable->getMessage() );

--- a/tests/Integration/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocketTest.php
@@ -256,7 +256,7 @@ final class UnixDomainSocketTest extends TestCase
 		$connection = new UnixDomainSocket(
 			$this->getUnixDomainSocket(),
 			Defaults::CONNECT_TIMEOUT,
-			1000
+			100
 		);
 		$client     = new Client( $connection );
 		$content    = http_build_query( ['test-key' => 'unit'] );
@@ -266,7 +266,7 @@ final class UnixDomainSocketTest extends TestCase
 
 		$this->assertSame( 'unit - 0', $response->getBody() );
 
-		$content = http_build_query( ['sleep' => 2, 'test-key' => 'unit'] );
+		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( __DIR__ . '/Workers/sleepWorker.php', $content );
 
 		$this->expectException( TimedoutException::class );

--- a/tests/Integration/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocketTest.php
@@ -648,4 +648,29 @@ final class UnixDomainSocketTest extends TestCase
 
 		$this->assertRegExp( $expectedError, $response->getError() );
 	}
+
+	/**
+	 * @throws ConnectException
+	 * @throws ExpectationFailedException
+	 * @throws Throwable
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+	 */
+	public function testSuccessiveRequestsShouldUseSameSocket() : void
+	{
+		$request = new GetRequest( __DIR__ . '/Workers/sleepWorker.php', '' );
+
+		$requestId = $this->client->sendRequest( $request )->getRequestId();
+
+		$requestIds = [];
+		for ( $i = 0; $i < 5; $i++ )
+		{
+			$requestIds[] = $this->client->sendRequest( $request )->getRequestId();
+		}
+
+		$expectedRequestIds = [$requestId, $requestId, $requestId, $requestId, $requestId];
+
+		$this->assertSame( $expectedRequestIds, $requestIds );
+	}
 }

--- a/tests/Traits/SocketDataProviding.php
+++ b/tests/Traits/SocketDataProviding.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Tests\Traits;
+
+trait SocketDataProviding
+{
+	final protected function getNetworkSocketHost() : string
+	{
+		return (string)$_ENV['network-socket-host'];
+	}
+
+	final protected function getNetworkSocketPort() : int
+	{
+		return (int)$_ENV['network-socket-port'];
+	}
+
+	final protected function getUnixDomainSocket() : string
+	{
+		return (string)$_ENV['unix-domain-socket'];
+	}
+
+	final protected function getRestrictedUnixDomainSocket() : string
+	{
+		return (string)$_ENV['restricted-unix-domain-socket'];
+	}
+
+	final protected function getNonExistingUnixDomainSocket() : string
+	{
+		return (string)$_ENV['non-existing-unix-domain-socket'];
+	}
+
+	final protected function getInvalidUnixDomainSocket() : string
+	{
+		return (string)$_ENV['invalid-unix-domain-socket'];
+	}
+}

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -32,6 +32,7 @@ use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
@@ -39,6 +40,8 @@ use Throwable;
 
 final class ClientTest extends TestCase
 {
+	use SocketDataProviding;
+
 	/**
 	 * @throws Exception
 	 * @throws Throwable
@@ -48,7 +51,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testConnectAttemptToNotExistingSocketThrowsException() : void
 	{
-		$connection = new UnixDomainSocket( '/tmp/not/existing.sock' );
+		$connection = new UnixDomainSocket( $this->getNonExistingUnixDomainSocket() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ConnectException::class );
@@ -67,7 +70,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testConnectAttemptToInvalidSocketThrowsException() : void
 	{
-		$testSocket = realpath( __DIR__ . '/Fixtures/test.sock' );
+		$testSocket = realpath( __DIR__ . $this->getInvalidUnixDomainSocket() );
 
 		$connection = new UnixDomainSocket( '' . $testSocket );
 		$client     = new Client( $connection );
@@ -84,7 +87,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testWaitingForUnknownRequestThrowsException() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ReadFailedException::class );
@@ -99,7 +102,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testWaitingForResponsesWithoutRequestsThrowsException() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ReadFailedException::class );
@@ -113,7 +116,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testHandlingUnknownRequestThrowsException() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ReadFailedException::class );
@@ -127,7 +130,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testHandlingUnknownRequestsThrowsException() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ReadFailedException::class );
@@ -144,7 +147,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testConnectAttemptToRestrictedUnixDomainSocketThrowsException() : void
 	{
-		$connection = new UnixDomainSocket( '/var/run/php7.1-ruds.sock' );
+		$connection = new UnixDomainSocket( $this->getRestrictedUnixDomainSocket() );
 		$client     = new Client( $connection );
 
 		$this->expectException( ConnectException::class );
@@ -161,7 +164,7 @@ final class ClientTest extends TestCase
 	 */
 	public function testHandlingReadyResponsesJustReturnsIfClientGotNoRequests() : void
 	{
-		$connection = new UnixDomainSocket( '/var/run/php7.1-ruds.sock' );
+		$connection = new UnixDomainSocket( $this->getUnixDomainSocket() );
 		$client     = new Client( $connection );
 
 		$this->assertFalse( $client->hasUnhandledResponses() );

--- a/tests/Unit/SocketConnections/NetworkSocketTest.php
+++ b/tests/Unit/SocketConnections/NetworkSocketTest.php
@@ -26,13 +26,17 @@ namespace hollodotme\FastCGI\Tests\Unit\SocketConnections;
 use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
 use hollodotme\FastCGI\SocketConnections\Defaults;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use function sprintf;
 
 final class NetworkSocketTest extends TestCase
 {
+	use SocketDataProviding;
+
 	/**
 	 * @throws ExpectationFailedException
 	 * @throws InvalidArgumentException
@@ -51,9 +55,11 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanGetDefaultValues() : void
 	{
-		$connection = new NetworkSocket( 'localhost', 9000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
 
-		$this->assertSame( 'tcp://localhost:9000', $connection->getSocketAddress() );
+		$expectedSocketAddress = sprintf( 'tcp://%s:%d', $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
+
+		$this->assertSame( $expectedSocketAddress, $connection->getSocketAddress() );
 		$this->assertSame( Defaults::CONNECT_TIMEOUT, $connection->getConnectTimeout() );
 		$this->assertSame( Defaults::READ_WRITE_TIMEOUT, $connection->getReadWriteTimeout() );
 	}
@@ -64,9 +70,11 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanGetSetValues() : void
 	{
-		$connection = new NetworkSocket( '127.0.0.1', 9001, 2000, 3000 );
+		$connection = new NetworkSocket( $this->getNetworkSocketHost(), $this->getNetworkSocketPort(), 2000, 3000 );
 
-		$this->assertSame( 'tcp://127.0.0.1:9001', $connection->getSocketAddress() );
+		$expectedSocketAddress = sprintf( 'tcp://%s:%d', $this->getNetworkSocketHost(), $this->getNetworkSocketPort() );
+
+		$this->assertSame( $expectedSocketAddress, $connection->getSocketAddress() );
 		$this->assertSame( 2000, $connection->getConnectTimeout() );
 		$this->assertSame( 3000, $connection->getReadWriteTimeout() );
 	}

--- a/tests/Unit/SocketConnections/UnixDomainSocketTest.php
+++ b/tests/Unit/SocketConnections/UnixDomainSocketTest.php
@@ -26,13 +26,17 @@ namespace hollodotme\FastCGI\Tests\Unit\SocketConnections;
 use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
 use hollodotme\FastCGI\SocketConnections\Defaults;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use function sprintf;
 
 final class UnixDomainSocketTest extends TestCase
 {
+	use SocketDataProviding;
+
 	/**
 	 * @throws ExpectationFailedException
 	 * @throws InvalidArgumentException
@@ -40,7 +44,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testImplementsConnectionInterface() : void
 	{
-		$connection = new UnixDomainSocket( '/var/run/php/php7.1-fpm.sock' );
+		$connection = new UnixDomainSocket( $this->getUnixDomainSocket() );
 
 		$this->assertInstanceOf( ConfiguresSocketConnection::class, $connection );
 	}
@@ -51,9 +55,11 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanGetDefaultValues() : void
 	{
-		$connection = new UnixDomainSocket( '/var/run/php/php7.1-fpm.sock' );
+		$connection = new UnixDomainSocket( $this->getUnixDomainSocket() );
 
-		$this->assertSame( 'unix:///var/run/php/php7.1-fpm.sock', $connection->getSocketAddress() );
+		$expectedSocketAddress = sprintf( 'unix://%s', $this->getUnixDomainSocket() );
+
+		$this->assertSame( $expectedSocketAddress, $connection->getSocketAddress() );
 		$this->assertSame( Defaults::CONNECT_TIMEOUT, $connection->getConnectTimeout() );
 		$this->assertSame( Defaults::READ_WRITE_TIMEOUT, $connection->getReadWriteTimeout() );
 	}
@@ -64,9 +70,11 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanGetSetValues() : void
 	{
-		$connection = new UnixDomainSocket( '/var/run/php/php7.1-fpm.sock', 2000, 3000 );
+		$connection = new UnixDomainSocket( $this->getUnixDomainSocket(), 2000, 3000 );
 
-		$this->assertSame( 'unix:///var/run/php/php7.1-fpm.sock', $connection->getSocketAddress() );
+		$expectedSocketAddress = sprintf( 'unix://%s', $this->getUnixDomainSocket() );
+
+		$this->assertSame( $expectedSocketAddress, $connection->getSocketAddress() );
 		$this->assertSame( 2000, $connection->getConnectTimeout() );
 		$this->assertSame( 3000, $connection->getReadWriteTimeout() );
 	}

--- a/tests/Unit/SocketTest.php
+++ b/tests/Unit/SocketTest.php
@@ -34,6 +34,7 @@ use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\Socket;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -43,6 +44,8 @@ use function http_build_query;
 
 final class SocketTest extends TestCase
 {
+	use SocketDataProviding;
+
 	/**
 	 * @throws Exception
 	 */
@@ -62,7 +65,7 @@ final class SocketTest extends TestCase
 	{
 		$nameValuePairEncoder = new NameValuePairEncoder();
 		$packetEncoder        = new PacketEncoder();
-		$connection           = new UnixDomainSocket( '/var/run/php-uds.sock' );
+		$connection           = new UnixDomainSocket( $this->getUnixDomainSocket() );
 
 		return new Socket( $connection, $packetEncoder, $nameValuePairEncoder );
 	}

--- a/tests/Unit/SocketTest.php
+++ b/tests/Unit/SocketTest.php
@@ -32,8 +32,8 @@ use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\Requests\PostRequest;
-use hollodotme\FastCGI\Socket;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Sockets\Socket;
 use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
@@ -142,7 +142,7 @@ final class SocketTest extends TestCase
 			http_build_query( $data )
 		);
 		$request->addResponseCallbacks(
-			function ( ProvidesResponseData $response )
+			static function ( ProvidesResponseData $response )
 			{
 				echo $response->getBody();
 			}
@@ -170,7 +170,7 @@ final class SocketTest extends TestCase
 			http_build_query( $data )
 		);
 		$request->addFailureCallbacks(
-			function ( Throwable $throwable )
+			static function ( Throwable $throwable )
 			{
 				echo $throwable->getMessage();
 			}

--- a/tests/Unit/Sockets/SocketCollectionTest.php
+++ b/tests/Unit/Sockets/SocketCollectionTest.php
@@ -1,0 +1,471 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Tests\Unit\Sockets;
+
+use hollodotme\FastCGI\Encoders\NameValuePairEncoder;
+use hollodotme\FastCGI\Encoders\PacketEncoder;
+use hollodotme\FastCGI\Exceptions\ConnectException;
+use hollodotme\FastCGI\Exceptions\ReadFailedException;
+use hollodotme\FastCGI\Exceptions\TimedoutException;
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
+use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
+use hollodotme\FastCGI\Requests\PostRequest;
+use hollodotme\FastCGI\Sockets\SocketCollection;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\RuntimeException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use function reset;
+use const STDIN;
+
+final class SocketCollectionTest extends TestCase
+{
+	use SocketDataProviding;
+
+	/** @var SocketCollection */
+	private $collection;
+
+	protected function setUp() : void
+	{
+		$this->collection = new SocketCollection();
+	}
+
+	protected function tearDown() : void
+	{
+		$this->collection = null;
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testCollectResources() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$socketOne = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$socketTwo = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$connectMethod = (new ReflectionClass( $socketOne ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socketOne );
+
+		$connectMethod = (new ReflectionClass( $socketTwo ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socketTwo );
+
+		$resources = [];
+		$socketOne->collectResource( $resources );
+		$socketTwo->collectResource( $resources );
+
+		$this->assertSame( $resources, $this->collection->collectResources() );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testGetByResource() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$connectMethod = (new ReflectionClass( $socket ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socket );
+
+		$resources = [];
+		$socket->collectResource( $resources );
+
+		$checkSocket = $this->collection->getByResource( reset( $resources ) );
+
+		$this->assertSame( $checkSocket, $socket );
+	}
+
+	/**
+	 * @throws AssertionFailedError
+	 * @throws ReadFailedException
+	 */
+	public function testThrowsExceptionIfSocketCannotBeFoundByResource() : void
+	{
+		$this->expectException( ReadFailedException::class );
+		$this->expectExceptionMessage( 'Socket not found for resource' );
+
+		/** @noinspection UnusedFunctionResultInspection */
+		$this->collection->getByResource( STDIN );
+
+		$this->fail( 'Expected a ReadFailedException for not found socket by resource.' );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testGetSocketIdsByResources() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$socketOne = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$socketTwo = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$connectMethod = (new ReflectionClass( $socketOne ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socketOne );
+
+		$connectMethod = (new ReflectionClass( $socketTwo ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socketTwo );
+
+		$resources = [];
+		$socketOne->collectResource( $resources );
+		$socketTwo->collectResource( $resources );
+
+		$expectedSocketIds = [$socketOne->getId(), $socketTwo->getId()];
+
+		$this->assertSame( $expectedSocketIds, $this->collection->getSocketIdsByResources( $resources ) );
+	}
+
+	/**
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 */
+	public function testEmptyCollectionHasNoIdleSocket() : void
+	{
+		$this->assertNull( $this->collection->getIdleSocket() );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testNewlyAddedSocketIsIdle() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->assertCount( 0, $this->collection );
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$this->assertSame( $socket, $this->collection->getIdleSocket() );
+	}
+
+	/**
+	 * @throws ConnectException
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 */
+	public function testSocketWithResponseIsIdle() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->assertCount( 0, $this->collection );
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$socket->sendRequest(
+			new PostRequest( '/some/script.php', '' )
+		);
+
+		/** @noinspection UnusedFunctionResultInspection */
+		$socket->fetchResponse();
+
+		$this->assertSame( $socket, $this->collection->getIdleSocket() );
+	}
+
+	/**
+	 * @throws ConnectException
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 */
+	public function testBusySocketIsNotIdle() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->assertCount( 0, $this->collection );
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$socket->sendRequest(
+			new PostRequest( '/some/script.php', '' )
+		);
+
+		$this->assertNull( $this->collection->getIdleSocket() );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 * @throws ReadFailedException
+	 */
+	public function testGetById() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$checkSocket = $this->collection->getById( $socket->getId() );
+
+		$this->assertSame( $checkSocket, $socket );
+	}
+
+	/**
+	 * @throws ReadFailedException
+	 * @throws AssertionFailedError
+	 */
+	public function testThrowsExceptionIfSocketCannotByFoundById() : void
+	{
+		$this->expectException( ReadFailedException::class );
+		$this->expectExceptionMessage( 'Socket not found for request ID: 123' );
+
+		/** @noinspection UnusedFunctionResultInspection */
+		$this->collection->getById( 123 );
+
+		$this->fail( 'Expected a ReadFailedException to be thrown.' );
+	}
+
+	/**
+	 * @return ConfiguresSocketConnection
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws Exception
+	 */
+	private function getSocketConnectionMock() : ConfiguresSocketConnection
+	{
+		$connection = $this->getMockBuilder( ConfiguresSocketConnection::class )->getMockForAbstractClass();
+		$connection->method( 'getSocketAddress' )->willReturn( 'unix://' . $this->getUnixDomainSocket() );
+
+		/** @var ConfiguresSocketConnection $connection */
+		return $connection;
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testNew() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$socketOne = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$this->assertGreaterThan( 0, $socketOne->getId() );
+		$this->assertCount( 1, $this->collection );
+		$this->assertSame( 1, $this->collection->count() );
+
+		$socketTwo = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$this->assertGreaterThan( 0, $socketTwo->getId() );
+		$this->assertNotSame( $socketOne->getId(), $socketTwo->getId() );
+		$this->assertCount( 2, $this->collection );
+		$this->assertSame( 2, $this->collection->count() );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testThrowsExceptionIfNoNewSocketCanBeCreated() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->expectException( WriteFailedException::class );
+
+		for ( $i = 0; $i < 66000; $i++ )
+		{
+			/** @noinspection UnusedFunctionResultInspection */
+			$this->collection->new( $connection, $packetEncoder, $nameValuePairEncoder );
+		}
+
+		$this->fail( 'Expected WriteFailedException to be thrown.' );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 * @throws ConnectException
+	 * @throws TimedoutException
+	 */
+	public function testHasBusySockets() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->assertCount( 0, $this->collection );
+		$this->assertFalse( $this->collection->hasBusySockets() );
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$socket->sendRequest(
+			new PostRequest( '/some/sctipt.php', '' )
+		);
+
+		$this->assertTrue( $this->collection->hasBusySockets() );
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws RuntimeException
+	 * @throws WriteFailedException
+	 */
+	public function testRemove() : void
+	{
+		$connection           = $this->getSocketConnectionMock();
+		$packetEncoder        = new PacketEncoder();
+		$nameValuePairEncoder = new NameValuePairEncoder();
+
+		$this->assertCount( 0, $this->collection );
+
+		$socket = $this->collection->new(
+			$connection,
+			$packetEncoder,
+			$nameValuePairEncoder
+		);
+
+		$this->assertCount( 1, $this->collection );
+
+		$this->collection->remove( $socket->getId() );
+
+		$this->assertCount( 0, $this->collection );
+	}
+
+	/**
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws Exception
+	 */
+	public function testCount() : void
+	{
+		$this->assertSame( 0, $this->collection->count() );
+		$this->assertCount( 0, $this->collection );
+	}
+
+	/**
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 */
+	public function testIsEmpty() : void
+	{
+		$this->assertTrue( $this->collection->isEmpty() );
+	}
+}

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-namespace hollodotme\FastCGI\Tests\Unit;
+namespace hollodotme\FastCGI\Tests\Unit\Sockets;
 
 use Exception;
 use hollodotme\FastCGI\Encoders\NameValuePairEncoder;
@@ -82,7 +82,7 @@ final class SocketTest extends TestCase
 		$socket  = $this->getSocket();
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
-			dirname( __DIR__ ) . '/Integration/Workers/worker.php',
+			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
 			http_build_query( $data )
 		);
 
@@ -111,7 +111,7 @@ final class SocketTest extends TestCase
 		$socket    = $this->getSocket();
 		$data      = ['test-key' => 'unit'];
 		$request   = new PostRequest(
-			dirname( __DIR__ ) . '/Integration/Workers/worker.php',
+			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
 			http_build_query( $data )
 		);
 
@@ -138,7 +138,7 @@ final class SocketTest extends TestCase
 		$socket  = $this->getSocket();
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
-			dirname( __DIR__ ) . '/Integration/Workers/worker.php',
+			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
 			http_build_query( $data )
 		);
 		$request->addResponseCallbacks(
@@ -166,7 +166,7 @@ final class SocketTest extends TestCase
 		$socket  = $this->getSocket();
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
-			dirname( __DIR__ ) . '/Integration/Workers/worker.php',
+			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
 			http_build_query( $data )
 		);
 		$request->addFailureCallbacks(

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -182,4 +182,26 @@ final class SocketTest extends TestCase
 
 		$this->expectOutputString( 'Something went wrong.' );
 	}
+
+	/**
+	 * @throws AssertionFailedError
+	 * @throws ConnectException
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 * @throws Exception
+	 */
+	public function testThrowsExceptionIfRequestIsSentToSocketThatIsNotIdle() : void
+	{
+		$socket  = $this->getSocket();
+		$request = new PostRequest( '/some/script.php', '' );
+
+		$socket->sendRequest( $request );
+
+		$this->expectException( ConnectException::class );
+		$this->expectExceptionMessage( 'Trying to connect to a socket that is not idle.' );
+
+		$socket->sendRequest( $request );
+
+		$this->fail( 'Expected ConnectException to be thrown.' );
+	}
 }

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -315,4 +315,25 @@ final class SocketTest extends TestCase
 
 		$this->assertFalse( $socket->isUsable() );
 	}
+
+	/**
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReflectionException
+	 * @throws Exception
+	 */
+	public function testIsNotUsableWhenSocketWasClosed() : void
+	{
+		$socket = $this->getSocket();
+
+		$connectMethod = (new ReflectionClass( $socket ))->getMethod( 'connect' );
+		$connectMethod->setAccessible( true );
+		$connectMethod->invoke( $socket );
+
+		$disconnectMethod = (new ReflectionClass( $socket ))->getMethod( 'disconnect' );
+		$disconnectMethod->setAccessible( true );
+		$disconnectMethod->invoke( $socket );
+
+		$this->assertFalse( $socket->isUsable() );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,18 +21,4 @@
  * SOFTWARE.
  */
 
-if (
-	extension_loaded( 'xdebug' )
-	&& version_compare( '2.6.0', phpversion( 'xdebug' ), '<=' )
-)
-{
-	/** @noinspection PhpUndefinedFunctionInspection */
-	/** @noinspection PhpUndefinedConstantInspection */
-	xdebug_set_filter(
-		XDEBUG_FILTER_CODE_COVERAGE,
-		XDEBUG_PATH_WHITELIST,
-		[dirname( __DIR__ ) . '/src']
-	);
-}
-
 require __DIR__ . '/../vendor/autoload.php';

--- a/tests/runTestsOnAllLocalPhpVersions.sh
+++ b/tests/runTestsOnAllLocalPhpVersions.sh
@@ -11,4 +11,4 @@ docker-compose exec php72 vendor/bin/phpunit8.phar -c build
 docker-compose exec php73 vendor/bin/phpunit8.phar -c build
 
 echo -e "\n\033[43mRun phpstan\033[0m\n"
-docker-compose run phpstan analyze --level max src/
+docker-compose run phpstan


### PR DESCRIPTION
## Proposed Changes

- Adding socket status: `INIT`, `IDLE` & `BUSY` to check for idle & reusable sockets
- Reset `response` property of Socket class when a new request is performed
- Do not disconnect & remove socket from list after response was received
- Remove sockets only from list, if it's not usable anymore (e.g. timed out or closed)
- Refactor socket list to an internal collection in order to cleanup operations on the socket list
- Tests for the newly introduced socket methods
- Tests for the newly introduced socket collection
- Tests for the re-using of idle sockets