### PR TITLE
Close unused socket connections when processing async requests

### DIFF
--- a/.docker/php/7.1/Dockerfile
+++ b/.docker/php/7.1/Dockerfile
@@ -1,10 +1,12 @@
 FROM php:7.1-fpm-alpine
+ENV XDEBUG_VERSION=2.7.2
 ENV PHP_CONF_DIR=/usr/local/etc
-RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.1 \
+RUN apk update && apk upgrade && apk add --no-cache ${PHPIZE_DEPS} \
+    && pecl install xdebug-${XDEBUG_VERSION} \
     && docker-php-ext-enable xdebug \
-    && apk del $PHPIZE_DEPS
-COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf
-COPY restricted-unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/restricted-unix-domain-socket.pool.conf
-COPY unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/unix-domain-socket.pool.conf
+    && apk del ${PHPIZE_DEPS} \
+    && rm -rf /var/cache/apk/*
+COPY network-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/network-socket.pool.conf
+COPY restricted-unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/restricted-unix-domain-socket.pool.conf
+COPY unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/unix-domain-socket.pool.conf
 WORKDIR /repo

--- a/.docker/php/7.2/Dockerfile
+++ b/.docker/php/7.2/Dockerfile
@@ -1,10 +1,12 @@
 FROM php:7.2-fpm-alpine
+ENV XDEBUG_VERSION=2.7.2
 ENV PHP_CONF_DIR=/usr/local/etc
-RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.1 \
+RUN apk update && apk upgrade && apk add --no-cache ${PHPIZE_DEPS} \
+    && pecl install xdebug-${XDEBUG_VERSION} \
     && docker-php-ext-enable xdebug \
-    && apk del $PHPIZE_DEPS
-COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf
-COPY restricted-unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/restricted-unix-domain-socket.pool.conf
-COPY unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/unix-domain-socket.pool.conf
+    && apk del ${PHPIZE_DEPS} \
+    && rm -rf /var/cache/apk/*
+COPY network-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/network-socket.pool.conf
+COPY restricted-unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/restricted-unix-domain-socket.pool.conf
+COPY unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/unix-domain-socket.pool.conf
 WORKDIR /repo

--- a/.docker/php/7.3/Dockerfile
+++ b/.docker/php/7.3/Dockerfile
@@ -1,10 +1,12 @@
 FROM php:7.3-fpm-alpine
+ENV XDEBUG_VERSION=2.7.2
 ENV PHP_CONF_DIR=/usr/local/etc
-RUN apk update && apk upgrade && apk add --no-cache $PHPIZE_DEPS \
-    && pecl install xdebug-2.7.1 \
+RUN apk update && apk upgrade && apk add --no-cache ${PHPIZE_DEPS} \
+    && pecl install xdebug-${XDEBUG_VERSION} \
     && docker-php-ext-enable xdebug \
-    && apk del $PHPIZE_DEPS
-COPY network-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/network-socket.pool.conf
-COPY restricted-unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/restricted-unix-domain-socket.pool.conf
-COPY unix-domain-socket.pool.conf $PHP_CONF_DIR/php-fpm.d/unix-domain-socket.pool.conf
+    && apk del ${PHPIZE_DEPS} \
+    && rm -rf /var/cache/apk/*
+COPY network-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/network-socket.pool.conf
+COPY restricted-unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/restricted-unix-domain-socket.pool.conf
+COPY unix-domain-socket.pool.conf ${PHP_CONF_DIR}/php-fpm.d/unix-domain-socket.pool.conf
 WORKDIR /repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.idea/
 /vendor/
 /build/logs/
-/.phpunit.result.cache
+/build/.phpunit.result.cache
 /composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [2.7.2] - YYYY-MM-DD
+
+### Fixed
+
+* Remove/close sockets after fetching their responses triggered async requests in order to prevent halt on further 
+  request processing, if the number of requests exceeds php-fpm's `pm.max_children` setting. - [#40]
+
 ## [2.7.1] - 2019-04-29
 
 ### Fixed
@@ -193,6 +200,7 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
  * Getters/Setters for connect timeout, read/write timeout, keep alive, socket persistence from `Client` (now part of the socket connection)
  * Method `Client->getValues()`
 
+[2.7.2]: https://github.com/hollodotme/fast-cgi-client/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/hollodotme/fast-cgi-client/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/hollodotme/fast-cgi-client/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/hollodotme/fast-cgi-client/compare/v2.5.0...v2.6.0
@@ -221,3 +229,4 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
 [#27]: https://github.com/hollodotme/fast-cgi-client/issues/27
 [#33]: https://github.com/hollodotme/fast-cgi-client/pull/33
 [#37]: https://github.com/hollodotme/fast-cgi-client/issue/37
+[#40]: https://github.com/hollodotme/fast-cgi-client/issue/40

--- a/src/Client.php
+++ b/src/Client.php
@@ -193,9 +193,11 @@ class Client
 		}
 		catch ( Throwable $e )
 		{
-			$this->sockets->remove( $socket->getId() );
-
 			$socket->notifyFailureCallbacks( $e );
+		}
+		finally
+		{
+			$this->sockets->remove( $socket->getId() );
 		}
 	}
 
@@ -264,6 +266,10 @@ class Client
 				yield $this->sockets->getById( $requestId )->fetchResponse( $timeoutMs );
 			}
 			catch ( Throwable $e )
+			{
+				# Skip unknown request ids
+			}
+			finally
 			{
 				$this->sockets->remove( $requestId );
 			}

--- a/tests/Integration/AsyncRequestsTest.php
+++ b/tests/Integration/AsyncRequestsTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Tests\Integration;
+
+use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\Exceptions\ConnectException;
+use hollodotme\FastCGI\Exceptions\ReadFailedException;
+use hollodotme\FastCGI\Exceptions\TimedoutException;
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
+use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\Requests\PostRequest;
+use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use Throwable;
+use function http_build_query;
+use function parse_ini_file;
+use function range;
+
+final class AsyncRequestsTest extends TestCase
+{
+	use SocketDataProviding;
+
+	/**
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws Throwable
+	 * @throws ConnectException
+	 * @throws ReadFailedException
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 */
+	public function testAsyncRequestsWillRespondIfRequestsExceedPhpFpmMaxChildrenSettingOnNetworkSocket() : void
+	{
+		$maxChildren = $this->getMaxChildrenSettingFromNetworkSocket();
+		$limit       = $maxChildren + 5;
+
+		$this->assertTrue( $limit > 5 );
+
+		$client          = $this->getClientWithNetworkSocket();
+		$results         = [];
+		$expectedResults = range( 0, $limit - 1 );
+
+		$request = new PostRequest( __DIR__ . '/Workers/worker.php', '' );
+		$request->addResponseCallbacks(
+			static function ( ProvidesResponseData $response ) use ( &$results )
+			{
+				$results[] = $response->getBody();
+			}
+		);
+
+		for ( $i = 0; $i < $limit; $i++ )
+		{
+			$request->setContent( http_build_query( ['test-key' => $i] ) );
+
+			$client->sendAsyncRequest( $request );
+		}
+
+		$client->waitForResponses();
+
+		$this->assertEquals( $expectedResults, $results );
+	}
+
+	private function getMaxChildrenSettingFromNetworkSocket() : int
+	{
+		$iniSettings = parse_ini_file(
+			__DIR__ . '/../../.docker/php/network-socket.pool.conf',
+			true
+		);
+
+		return (int)$iniSettings['network']['pm.max_children'];
+	}
+
+	private function getClientWithNetworkSocket() : Client
+	{
+		$networkSocket = new NetworkSocket(
+			$this->getNetworkSocketHost(),
+			$this->getNetworkSocketPort()
+		);
+
+		return new Client( $networkSocket );
+	}
+
+	/**
+	 * @throws ConnectException
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws Throwable
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 */
+	public function testAsyncRequestsWillRespondIfRequestsExceedPhpFpmMaxChildrenSettingOnUnixDomainSocket() : void
+	{
+		$maxChildren = $this->getMaxChildrenSettingFromUnixDomainSocket();
+		$limit       = $maxChildren + 5;
+
+		$this->assertTrue( $limit > 5 );
+
+		$client          = $this->getClientWithUnixDomainSocket();
+		$results         = [];
+		$expectedResults = range( 0, $limit - 1 );
+
+		$request = new PostRequest( __DIR__ . '/Workers/worker.php', '' );
+		$request->addResponseCallbacks(
+			static function ( ProvidesResponseData $response ) use ( &$results )
+			{
+				$results[] = $response->getBody();
+			}
+		);
+
+		for ( $i = 0; $i < $limit; $i++ )
+		{
+			$request->setContent( http_build_query( ['test-key' => $i] ) );
+
+			$client->sendAsyncRequest( $request );
+		}
+
+		$client->waitForResponses();
+
+		$this->assertEquals( $expectedResults, $results );
+	}
+
+	private function getMaxChildrenSettingFromUnixDomainSocket() : int
+	{
+		$iniSettings = parse_ini_file(
+			__DIR__ . '/../../.docker/php/unix-domain-socket.pool.conf',
+			true
+		);
+
+		return (int)$iniSettings['uds']['pm.max_children'];
+	}
+
+	private function getClientWithUnixDomainSocket() : Client
+	{
+		$unixDomainSocket = new UnixDomainSocket( $this->getUnixDomainSocket() );
+
+		return new Client( $unixDomainSocket );
+	}
+}

--- a/tests/Integration/AsyncRequestsTest.php
+++ b/tests/Integration/AsyncRequestsTest.php
@@ -19,6 +19,7 @@ use Throwable;
 use function http_build_query;
 use function parse_ini_file;
 use function range;
+use function sort;
 
 final class AsyncRequestsTest extends TestCase
 {
@@ -48,7 +49,7 @@ final class AsyncRequestsTest extends TestCase
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( &$results )
 			{
-				$results[] = $response->getBody();
+				$results[] = (int)$response->getBody();
 			}
 		);
 
@@ -60,6 +61,8 @@ final class AsyncRequestsTest extends TestCase
 		}
 
 		$client->waitForResponses();
+
+		sort( $results );
 
 		$this->assertEquals( $expectedResults, $results );
 	}
@@ -108,7 +111,7 @@ final class AsyncRequestsTest extends TestCase
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( &$results )
 			{
-				$results[] = $response->getBody();
+				$results[] = (int)$response->getBody();
 			}
 		);
 
@@ -120,6 +123,8 @@ final class AsyncRequestsTest extends TestCase
 		}
 
 		$client->waitForResponses();
+
+		sort( $results );
 
 		$this->assertEquals( $expectedResults, $results );
 	}


### PR DESCRIPTION
Related to issue #40

## Proposed Changes

- Remove/close socket from internal collection in `Client#readResponses()` after response was fetched
- Remove/close socket from internal collection in `Client#fetchResponseAndNotifyCallback()` after response was handled
- Update of docker build environment (PHP & Xdebug versions)

## Further comments

The introduction of re-using idle sockets in `v2.7.0` caused the issue that finished async requests kept their socket connections to php-fpm open forever. If the number of parallel async requests exceeds the number of allowed `pm.max_children` further requests were not processed anymore as php-fpm was expecting to get new requests through the already open, idle socket connections.