### PR TITLE
Add proper handling of stream_select return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CH
 
 ## [2.7.2] - YYYY-MM-DD
 
+### Improved
+
+* Handling of `stream_select` returning `false` in case of a system call interrupt. - [#41]
+
 ### Fixed
 
 * Remove/close sockets after fetching their responses triggered async requests in order to prevent halt on further 
@@ -230,3 +234,4 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
 [#33]: https://github.com/hollodotme/fast-cgi-client/pull/33
 [#37]: https://github.com/hollodotme/fast-cgi-client/issue/37
 [#40]: https://github.com/hollodotme/fast-cgi-client/issue/40
+[#41]: https://github.com/hollodotme/fast-cgi-client/issue/41

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "keywords": [
     "fastcgi",
     "php-fpm",
-    "socket"
+    "socket",
+    "async"
   ],
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/src/Client.php
+++ b/src/Client.php
@@ -172,10 +172,7 @@ class Client
 
 		while ( $this->hasUnhandledResponses() )
 		{
-			foreach ( $this->getSocketsHavingResponse() as $socket )
-			{
-				$this->fetchResponseAndNotifyCallback( $socket, $timeoutMs );
-			}
+			$this->handleReadyResponses( $timeoutMs );
 		}
 	}
 
@@ -210,18 +207,6 @@ class Client
 	}
 
 	/**
-	 * @return Generator|Socket[]
-	 * @throws ReadFailedException
-	 */
-	private function getSocketsHavingResponse() : Generator
-	{
-		foreach ( $this->getRequestIdsHavingResponse() as $requestId )
-		{
-			yield $this->sockets->getById( $requestId );
-		}
-	}
-
-	/**
 	 * @param int $requestId
 	 *
 	 * @return bool
@@ -246,7 +231,7 @@ class Client
 		$reads  = $this->sockets->collectResources();
 		$writes = $excepts = null;
 
-		stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
+		@stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
 
 		return $this->sockets->getSocketIdsByResources( $reads );
 	}

--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,12 @@ class Client
 		$reads  = $this->sockets->collectResources();
 		$writes = $excepts = null;
 
-		@stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
+		$result = @stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
+
+		if ( false === $result || 0 === count( $reads ) )
+		{
+			return [];
+		}
 
 		return $this->sockets->getSocketIdsByResources( $reads );
 	}

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -52,8 +52,10 @@ use function stream_get_meta_data;
 use function stream_select;
 use function stream_set_timeout;
 use function stream_socket_client;
+use function stream_socket_shutdown;
 use function strlen;
 use function substr;
+use const STREAM_SHUT_RDWR;
 
 final class Socket
 {
@@ -541,6 +543,7 @@ final class Socket
 	{
 		if ( is_resource( $this->resource ) )
 		{
+			@stream_socket_shutdown( $this->resource, STREAM_SHUT_RDWR );
 			fclose( $this->resource );
 		}
 	}

--- a/tests/Integration/SignaledWorkersTest.php
+++ b/tests/Integration/SignaledWorkersTest.php
@@ -1,0 +1,199 @@
+<?php declare(strict_types=1);
+
+namespace hollodotme\FastCGI\Tests\Integration;
+
+use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\Exceptions\ConnectException;
+use hollodotme\FastCGI\Exceptions\ReadFailedException;
+use hollodotme\FastCGI\Exceptions\TimedoutException;
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
+use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\Requests\PostRequest;
+use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
+use hollodotme\FastCGI\Tests\Traits\SocketDataProviding;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+use Throwable;
+use function escapeshellarg;
+use function http_build_query;
+use function preg_match;
+use function shell_exec;
+use function sleep;
+
+final class SignaledWorkersTest extends TestCase
+{
+	use SocketDataProviding;
+
+	/**
+	 * @param int $signal
+	 *
+	 * @throws ConnectException
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws Throwable
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 *
+	 * @dataProvider signalProvider
+	 */
+	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnNetworkSocket( int $signal ) : void
+	{
+		$client   = $this->getClientWithNetworkSocket();
+		$request  = new PostRequest( __DIR__ . '/Workers/worker.php', '' );
+		$success  = [];
+		$failures = [];
+
+		$request->addResponseCallbacks(
+			static function ( ProvidesResponseData $response ) use ( &$success )
+			{
+				$success[] = (int)$response->getBody();
+			}
+		);
+
+		$request->addFailureCallbacks(
+			static function ( Throwable $e ) use ( &$failures )
+			{
+				$failures[] = $e;
+			}
+		);
+
+		for ( $i = 0; $i < 3; $i++ )
+		{
+			$request->setContent( http_build_query( ['test-key' => $i] ) );
+
+			$client->sendAsyncRequest( $request );
+		}
+
+		$pids = $this->getPoolWorkerPIDs( 'pool network' );
+
+		$this->killPoolWorker( (int)$pids[0], $signal );
+
+		$client->waitForResponses();
+
+		$this->assertCount( 2, $success );
+		$this->assertCount( 1, $failures );
+		$this->assertContainsOnlyInstancesOf( ReadFailedException::class, $failures );
+
+		sleep( 1 );
+	}
+
+	public function signalProvider() : array
+	{
+		return [
+			[
+				# SIGHUP
+				'signal' => 1,
+			],
+			[
+				# SIGINT
+				'signal' => 2,
+			],
+			[
+				# SIGKILL
+				'signal' => 9,
+			],
+			[
+				# SIGTERM
+				'signal' => 15,
+			],
+		];
+	}
+
+	private function getClientWithNetworkSocket() : Client
+	{
+		$networkSocket = new NetworkSocket(
+			$this->getNetworkSocketHost(),
+			$this->getNetworkSocketPort()
+		);
+
+		return new Client( $networkSocket );
+	}
+
+	private function getPoolWorkerPIDs( string $poolName ) : array
+	{
+		$command = sprintf(
+			'ps -o pid,args | grep %s | grep -v "grep"',
+			escapeshellarg( $poolName )
+		);
+		$list    = shell_exec( $command );
+
+		return array_map(
+			static function ( string $item )
+			{
+				preg_match( '#^(\d+)\s.+$#', trim( $item ), $matches );
+
+				return (int)$matches[1];
+			},
+			explode( "\n", $list )
+		);
+	}
+
+	private function killPoolWorker( int $PID, int $signal ) : void
+	{
+		$command = sprintf( 'kill -%d %d', $signal, $PID );
+		exec( $command );
+	}
+
+	/**
+	 * @param int $signal
+	 *
+	 * @throws ConnectException
+	 * @throws ExpectationFailedException
+	 * @throws InvalidArgumentException
+	 * @throws ReadFailedException
+	 * @throws Throwable
+	 * @throws TimedoutException
+	 * @throws WriteFailedException
+	 * @dataProvider signalProvider
+	 */
+	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnUnixDomainSocket( int $signal ) : void
+	{
+		$client   = $this->getClientWithUnixDomainSocket();
+		$request  = new PostRequest( __DIR__ . '/Workers/worker.php', '' );
+		$success  = [];
+		$failures = [];
+
+		$request->addResponseCallbacks(
+			static function ( ProvidesResponseData $response ) use ( &$success )
+			{
+				$success[] = (int)$response->getBody();
+			}
+		);
+
+		$request->addFailureCallbacks(
+			static function ( Throwable $e ) use ( &$failures )
+			{
+				$failures[] = $e;
+			}
+		);
+
+		for ( $i = 0; $i < 3; $i++ )
+		{
+			$request->setContent( http_build_query( ['test-key' => $i] ) );
+
+			$client->sendAsyncRequest( $request );
+		}
+
+		$pids = $this->getPoolWorkerPIDs( 'pool uds' );
+
+		$this->killPoolWorker( (int)$pids[0], $signal );
+
+		$client->waitForResponses();
+
+		$this->assertCount( 2, $success );
+		$this->assertCount( 1, $failures );
+		$this->assertContainsOnlyInstancesOf( ReadFailedException::class, $failures );
+
+		sleep( 1 );
+	}
+
+	private function getClientWithUnixDomainSocket() : Client
+	{
+		$unixDomainSocket = new UnixDomainSocket( $this->getUnixDomainSocket() );
+
+		return new Client( $unixDomainSocket );
+	}
+}

--- a/tests/runTestsOnAllLocalPhpVersions.sh
+++ b/tests/runTestsOnAllLocalPhpVersions.sh
@@ -3,12 +3,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )")"
 cd "$(dirname "${DIR}" )" >/dev/null 2>&1
 
-docker-compose up -d
+docker-compose up -d php71 php72 php73
 
 echo -e "\n\033[43mRun PHPUnit\033[0m\n"
+echo -e "\n\033[33mOn PHP 7.1\033[0m\n"
 docker-compose exec php71 vendor/bin/phpunit7.phar -c build
+echo -e "\n\033[33mOn PHP 7.2\033[0m\n"
 docker-compose exec php72 vendor/bin/phpunit8.phar -c build
+echo -e "\n\033[33mOn PHP 7.3\033[0m\n"
 docker-compose exec php73 vendor/bin/phpunit8.phar -c build
 
 echo -e "\n\033[43mRun phpstan\033[0m\n"
-docker-compose run phpstan
+docker-compose run --rm phpstan


### PR DESCRIPTION
Related to issue #41 

## Proposed Changes

- Add integration tests to check for correct behavior, if php-fpm processes get interrupted by signals
- Add proper read/write shut down of sockets before removing them
- Handle `false` return value of `stream_select()` explicitly in `Client#getRequestIdsHavingResponse()`