### PR TITLE
Revert BC break in 3.1.0

### DIFF
--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -85,7 +85,7 @@ abstract class AbstractRequest implements ProvidesRequestData
 	/** @var array<callable> */
 	private $passThroughCallbacks = [];
 
-	final public function __construct( string $scriptFilename, string $content )
+	public function __construct( string $scriptFilename, string $content )
 	{
 		$this->scriptFilename = $scriptFilename;
 		$this->setContent( $content );


### PR DESCRIPTION
This reverts a BC break introduced in 3.1.0. 

Please merge and patch 3.1.1 as quick as possible. 