### PR TITLE
Exclude directories from the Composer archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Do not export those files in the Composer archive (lighter dependency)
+.circleci/ export-ignore
+.docker/ export-ignore
+.github/ export-ignore
+bin/ export-ignore
+build/ export-ignore
+tests/ export-ignore
+CHANGELOG.md export-ignore


### PR DESCRIPTION
## Proposed Changes 

This results in a lighter package when it is installed in `vendor` in consuming projects. This makes a difference on AWS Lambda where the package size is limited, and a smaller package implies better performances for cold starts.

See https://madewithlove.com/gitattributes/ for more information.
