### PR TITLE
Release v3.1.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Do not export those files in the Composer archive (lighter dependency)
+.circleci/ export-ignore
+.docker/ export-ignore
+.github/ export-ignore
+bin/ export-ignore
+build/ export-ignore
+tests/ export-ignore
+CHANGELOG.md export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [3.1.2] - 2020-05-19
+
+### Added
+
+* `.gitattributes` file to exclude non-relevant files/directories from archives/releases installed by composer - [#58]
+
+### Fixed
+
+* Remove link to `bin/fcgiget` in `composer.json` as it is a potential security issue (because `bin/fcgiget` accepts any accessible fastCGI endpoint and may be exposed in some setups)
+
 ## [3.1.1] - 2020-05-06
 
 ### Fixed
@@ -328,6 +338,7 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
  * Getters/Setters for connect timeout, read/write timeout, keep alive, socket persistence from `Client` (now part of the socket connection)
  * Method `Client->getValues()`
 
+[3.1.2]: https://github.com/hollodotme/fast-cgi-client/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/hollodotme/fast-cgi-client/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/hollodotme/fast-cgi-client/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/hollodotme/fast-cgi-client/compare/v3.0.0...v3.0.1
@@ -373,3 +384,4 @@ Based on [Pierrick Charron](https://github.com/adoy)'s [PHP-FastCGI-Client](http
 [#53]: https://github.com/hollodotme/fast-cgi-client/issues/53
 [#55]: https://github.com/hollodotme/fast-cgi-client/pull/55
 [#56]: https://github.com/hollodotme/fast-cgi-client/issues/56
+[#58]: https://github.com/hollodotme/fast-cgi-client/pull/58

--- a/LICENSE
+++ b/LICENSE
@@ -22,6 +22,11 @@ SOFTWARE.
 Contributors:
 
 * https://github.com/dugwood (Yvan Taviaud)
+* https://github.com/zackse (Evan Zacks)
+* https://github.com/themsaid (Mohamed Said)
+* https://github.com/teanooki (Markus)
+* https://github.com/jdreesen (Jacob Dreesen)
 * https://github.com/rbro
 * https://github.com/theseer (Arne Blankerts)
 * https://github.com/andybee (Andy Buckingham)
+* https://github.com/mnapoli (Matthieu Napoli)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please see the following links for earlier releases:
 
 * PHP >= 7.0 (EOL) [v1.0.0], [v1.0.1], [v1.1.0], [v1.2.0], [v1.3.0], [v1.4.0], [v1.4.1], [v1.4.2] 
 * PHP >= 7.1 [v2.0.0], [v2.0.1], [v2.1.0], [v2.2.0], [v2.3.0], [v2.4.0], [v2.4.1], [v2.4.2], [v2.4.3], [v2.5.0], [v2.6.0], [v2.7.0], [v2.7.1],
-  [v2.7.2], [v3.0.0-alpha], [v3.0.0-beta], [v3.0.0], [v3.0.1], [v3.1.0]
+  [v2.7.2], [v3.0.0-alpha], [v3.0.0-beta], [v3.0.0], [v3.0.1], [v3.1.0], [v3.1.1]
 
 Read more about the journey to and changes in `v2.6.0` in [this blog post](https://github.com/hollodotme/fast-cgi-client/wiki/Background-Info-FastCgiClient-Version-2.6.0).
 
@@ -975,7 +975,9 @@ if ('File not found.' === trim($response->getBody()))
 
     sh tests/runTestsOnAllLocalPhpVersions.sh
 
-## Command line tool (for debugging only)
+## Command line tool (for local debugging only)
+
+**Please note:** `bin/fcgiget` is not included and linked to `vendor/bin` via composer anymore since version `v3.1.2` for security reasons. [Read more.](https://github.com/hollodotme/fast-cgi-client/pull/58)
 
 Run a call through a network socket:
 
@@ -988,6 +990,7 @@ Run a call through a Unix Domain Socket
 This shows the response of the php-fpm status page.
 
 
+[v3.1.1]: https://github.com/hollodotme/fast-cgi-client/blob/v3.1.1/README.md
 [v3.1.0]: https://github.com/hollodotme/fast-cgi-client/blob/v3.1.0/README.md
 [v3.0.1]: https://github.com/hollodotme/fast-cgi-client/blob/v3.0.1/README.md
 [v3.0.0]: https://github.com/hollodotme/fast-cgi-client/blob/v3.0.0/README.md

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
       "email": "hw@hollo.me"
     }
   ],
-  "bin": [
-    "bin/fcgiget"
-  ],
   "autoload": {
     "psr-4": {
       "hollodotme\\FastCGI\\": "src/"


### PR DESCRIPTION
## Proposed Changes

- Add `.gitattributes` to exclude directories/files from archives/releases installed by composer
- Remove link to `bin/fcgiget` in `composer.json` as it is a potential security issue (because `bin/fcgiget` accepts any accessible fastCGI endpoint and may be exposed in some setups.

## Further comments

See #58.