### PR TITLE
Refactor abstract request

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ echo $_REQUEST['key'] ?? '';
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
-$content    = http_build_query(['key' => 'value']);
+$content    = new UrlEncodedFormData(['key' => 'value']);
 $request    = new PostRequest('/path/to/target/script.php', $content);
 
 $response = $client->sendRequest($connection, $request);
@@ -132,12 +133,13 @@ value
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
-$content    = http_build_query(['key' => 'value']);
+$content    = new UrlEncodedFormData(['key' => 'value']);
 $request    = new PostRequest('/path/to/target/script.php', $content);
 
 $socketId = $client->sendAsyncRequest($connection, $request);
@@ -153,12 +155,13 @@ echo "Request sent, got ID: {$socketId}";
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
-$content    = http_build_query(['key' => 'value']);
+$content    = new UrlEncodedFormData(['key' => 'value']);
 $request    = new PostRequest('/path/to/target/script.php', $content);
 
 $socketId = $client->sendAsyncRequest($connection, $request);
@@ -193,6 +196,7 @@ received instead of returning it, you need to use the `waitForResponse(int $sock
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
@@ -200,7 +204,7 @@ use Throwable;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
-$content    = http_build_query(['key' => 'value']);
+$content    = new UrlEncodedFormData(['key' => 'value']);
 $request    = new PostRequest('/path/to/target/script.php', $content);
 
 # Register a response callback, expects a `ProvidesResponseData` instance as the only parameter
@@ -262,15 +266,16 @@ value
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
 
-$request1 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '1']));
-$request2 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '2']));
-$request3 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '3']));
+$request1 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '1']));
+$request2 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '2']));
+$request3 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '3']));
 
 $socketIds = [];
 
@@ -305,15 +310,16 @@ foreach ($client->readResponses(3000, ...$socketIds) as $response)
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 
 $client     = new Client();
 $connection = new NetworkSocket('127.0.0.1', 9000);
 
-$request1 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '1', 'sleep' => 3]));
-$request2 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '2', 'sleep' => 2]));
-$request3 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '3', 'sleep' => 1]));
+$request1 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '1', 'sleep' => 3]));
+$request2 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '2', 'sleep' => 2]));
+$request3 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '3', 'sleep' => 1]));
 
 $socketIds = [];
 
@@ -384,6 +390,7 @@ while ( $client->hasUnhandledResponses() )
 namespace YourVendor\YourProject;
 
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
@@ -402,9 +409,9 @@ $failureCallback = static function ( Throwable $throwable )
 	echo $throwable->getMessage();	
 };
 
-$request1 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '1', 'sleep' => 3]));
-$request2 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '2', 'sleep' => 2]));
-$request3 = new PostRequest('/path/to/target/script.php', http_build_query(['key' => '3', 'sleep' => 1]));
+$request1 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '1', 'sleep' => 3]));
+$request2 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '2', 'sleep' => 2]));
+$request3 = new PostRequest('/path/to/target/script.php', new UrlEncodedFormData(['key' => '3', 'sleep' => 1]));
 
 $request1->addResponseCallbacks($responseCallback);
 $request1->addFailureCallbacks($failureCallback);
@@ -505,7 +512,7 @@ $passThroughCallback = static function( string $outputBuffer, string $errorBuffe
 	echo 'Error: ' . $errorBuffer;
 };
 
-$request = new GetRequest('/path/to/target/script.php', '');
+$request = new GetRequest('/path/to/target/script.php');
 $request->addPassThroughCallbacks( $passThroughCallback );
 
 $client->sendAsyncRequest($connection, $request);
@@ -629,10 +636,10 @@ interface ComposesRequestContent
 ```php
 <?php declare(strict_types=1);
 
-use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
-use hollodotme\FastCGI\SocketConnections\NetworkSocket;
-use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
+use hollodotme\FastCGI\Requests\PostRequest;
 
 $client = new Client();
 $connection = new NetworkSocket( '127.0.0.1', 9000 );

--- a/bin/examples.php
+++ b/bin/examples.php
@@ -3,6 +3,7 @@
 namespace hollodotme\FastCGI;
 
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
 
@@ -38,7 +39,7 @@ $connection = new UnixDomainSocket( '/var/run/php-uds.sock' );
 
 $workerPath = __DIR__ . '/exampleWorker.php';
 
-$request = new PostRequest( $workerPath, '' );
+$request = new PostRequest( $workerPath );
 
 printLine( "\n" );
 printLine( 'hollodotme/fast-cgi-client examples', 'blue', true );
@@ -59,7 +60,7 @@ printLine( '# Sending one synchronous request... (worker sleeps 1 second)' );
 printLine( 'CODE: $client->sendRequest( $request );', 'red' );
 printLine( "\n" );
 
-$request->setContent( http_build_query( ['sleep' => 1, 'key' => 'single synchronous request'] ) );
+$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single synchronous request'] ) );
 
 sleep( 2 );
 
@@ -75,7 +76,7 @@ printLine( '# Sending one asynchronous request... (worker sleeps 1 second)' );
 printLine( 'CODE: $client->sendAsyncRequest( $request );', 'red' );
 printLine( "\n" );
 
-$request->setContent( http_build_query( ['sleep' => 1, 'key' => 'single asynchronous request'] ) );
+$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request'] ) );
 
 sleep( 2 );
 
@@ -109,7 +110,7 @@ printLine( '        }', 'red' );
 printLine( '      );', 'red' );
 printLine( "\n" );
 
-$request->setContent( http_build_query( ['sleep' => 1, 'key' => 'single asynchronous request with callback'] ) );
+$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request with callback'] ) );
 $request->addResponseCallbacks(
 	static function ( ProvidesResponseData $response )
 	{
@@ -156,9 +157,9 @@ printLine( '      $client->sendAsyncRequest( $request2 );', 'red' );
 printLine( '      $client->sendAsyncRequest( $request3 );', 'red' );
 printLine( "\n" );
 
-$request1 = new PostRequest( $workerPath, http_build_query( ['sleep' => 1, 'key' => 'Request 1'] ) );
-$request2 = new PostRequest( $workerPath, http_build_query( ['sleep' => 1, 'key' => 'Request 2'] ) );
-$request3 = new PostRequest( $workerPath, http_build_query( ['sleep' => 1, 'key' => 'Request 3'] ) );
+$request1 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'Request 1'] ) );
+$request2 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'Request 2'] ) );
+$request3 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'Request 3'] ) );
 
 $socketIds = [];
 
@@ -199,9 +200,9 @@ printLine( '      $client->sendAsyncRequest( $request2 );', 'red' );
 printLine( '      $client->sendAsyncRequest( $request3 );', 'red' );
 printLine( "\n" );
 
-$request1 = new PostRequest( $workerPath, http_build_query( ['sleep' => 3, 'key' => 'Request 1'] ) );
-$request2 = new PostRequest( $workerPath, http_build_query( ['sleep' => 2, 'key' => 'Request 2'] ) );
-$request3 = new PostRequest( $workerPath, http_build_query( ['sleep' => 1, 'key' => 'Request 3'] ) );
+$request1 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 3, 'key' => 'Request 1'] ) );
+$request2 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 2, 'key' => 'Request 2'] ) );
+$request3 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'Request 3'] ) );
 
 $socketIds = [];
 
@@ -260,9 +261,9 @@ $responseCallback = static function ( ProvidesResponseData $response )
 	printResponse( $response );
 };
 
-$request1 = new PostRequest( $workerPath, http_build_query( ['sleep' => 2, 'key' => 'Request 1'] ) );
-$request2 = new PostRequest( $workerPath, http_build_query( ['sleep' => 3, 'key' => 'Request 2'] ) );
-$request3 = new PostRequest( $workerPath, http_build_query( ['sleep' => 1, 'key' => 'Request 3'] ) );
+$request1 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 2, 'key' => 'Request 1'] ) );
+$request2 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 3, 'key' => 'Request 2'] ) );
+$request3 = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'Request 3'] ) );
 
 $request1->addResponseCallbacks( $responseCallback );
 $request2->addResponseCallbacks( $responseCallback );

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,14 +22,11 @@ use function stream_select;
 
 class Client
 {
-	/** @var SocketCollection */
-	private $sockets;
+	private SocketCollection $sockets;
 
-	/** @var EncodesPacket */
-	private $packetEncoder;
+	private EncodesPacket $packetEncoder;
 
-	/** @var EncodesNameValuePair */
-	private $nameValuePairEncoder;
+	private EncodesNameValuePair $nameValuePairEncoder;
 
 	public function __construct()
 	{

--- a/src/Interfaces/ProvidesRequestData.php
+++ b/src/Interfaces/ProvidesRequestData.php
@@ -32,7 +32,7 @@ interface ProvidesRequestData
 
 	public function getContentLength() : int;
 
-	public function getContent() : string;
+	public function getContent() : ?ComposesRequestContent;
 
 	/**
 	 * @return array<string, mixed>

--- a/src/RequestContents/JsonData.php
+++ b/src/RequestContents/JsonData.php
@@ -9,14 +9,11 @@ use const PHP_INT_MAX;
 
 final class JsonData implements ComposesRequestContent
 {
-	/** @var mixed */
-	private $data;
+	private mixed $data;
 
-	/** @var int */
-	private $encodingOptions;
+	private int $encodingOptions;
 
-	/** @var int<1, max> */
-	private $encodingDepth;
+	private int $encodingDepth;
 
 	/**
 	 * @param mixed $data

--- a/src/RequestContents/JsonData.php
+++ b/src/RequestContents/JsonData.php
@@ -9,7 +9,7 @@ use const PHP_INT_MAX;
 
 final class JsonData implements ComposesRequestContent
 {
-	private mixed $data;
+	private $data;
 
 	private int $encodingOptions;
 

--- a/src/RequestContents/JsonData.php
+++ b/src/RequestContents/JsonData.php
@@ -9,7 +9,7 @@ use const PHP_INT_MAX;
 
 final class JsonData implements ComposesRequestContent
 {
-	private $data;
+	private mixed $data;
 
 	private int $encodingOptions;
 

--- a/src/RequestContents/MultipartFormData.php
+++ b/src/RequestContents/MultipartFormData.php
@@ -20,10 +20,10 @@ final class MultipartFormData implements ComposesRequestContent
 	private const FILE_CONTENT_TYPE_DEFAULT = 'application/octet-stream';
 
 	/** @var array<string, string> */
-	private $formData;
+	private array $formData;
 
 	/** @var array<string, string> */
-	private $files;
+	private array $files;
 
 	/**
 	 * @param array<string, string> $formData

--- a/src/RequestContents/UrlEncodedFormData.php
+++ b/src/RequestContents/UrlEncodedFormData.php
@@ -8,7 +8,7 @@ use function http_build_query;
 final class UrlEncodedFormData implements ComposesRequestContent
 {
 	/** @var array<string, mixed> */
-	private $formData;
+	private array $formData;
 
 	/**
 	 * @param array<string, mixed> $formData

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -12,56 +12,43 @@ use function strlen;
  */
 abstract class AbstractRequest implements ProvidesRequestData
 {
-	/** @var string */
-	private $gatewayInterface = 'FastCGI/1.0';
+	private string $gatewayInterface = 'FastCGI/1.0';
 
-	/** @var string */
-	private $scriptFilename;
+	private string $scriptFilename;
 
-	/** @var string */
-	private $serverSoftware = 'hollodotme/fast-cgi-client';
+	private string $serverSoftware = 'hollodotme/fast-cgi-client';
 
-	/** @var string */
-	private $remoteAddress = '192.168.0.1';
+	private string $remoteAddress = '192.168.0.1';
 
-	/** @var int */
-	private $remotePort = 9985;
+	private int $remotePort = 9985;
 
-	/** @var string */
-	private $serverAddress = '127.0.0.1';
+	private string $serverAddress = '127.0.0.1';
 
-	/** @var int */
-	private $serverPort = 80;
+	private int $serverPort = 80;
 
-	/** @var string */
-	private $serverName = 'localhost';
+	private string $serverName = 'localhost';
 
-	/** @var string */
-	private $serverProtocol = ServerProtocol::HTTP_1_1;
+	private string $serverProtocol = ServerProtocol::HTTP_1_1;
 
-	/** @var string */
-	private $contentType = 'application/x-www-form-urlencoded';
+	private string $contentType = 'application/x-www-form-urlencoded';
 
-	/** @var int */
-	private $contentLength = 0;
+	private int $contentLength = 0;
 
-	/** @var string */
-	private $content;
+	private string $content;
 
 	/** @var array<string, mixed> */
-	private $customVars = [];
+	private array $customVars = [];
 
-	/** @var string */
-	private $requestUri = '';
-
-	/** @var array<callable> */
-	private $responseCallbacks = [];
+	private string $requestUri = '';
 
 	/** @var array<callable> */
-	private $failureCallbacks = [];
+	private array $responseCallbacks = [];
 
 	/** @var array<callable> */
-	private $passThroughCallbacks = [];
+	private array $failureCallbacks = [];
+
+	/** @var array<callable> */
+	private array $passThroughCallbacks = [];
 
 	public function __construct( string $scriptFilename, string $content )
 	{

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -3,6 +3,7 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\ServerProtocol;
+use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 use hollodotme\FastCGI\Interfaces\ProvidesRequestData;
 use function strlen;
 
@@ -34,7 +35,7 @@ abstract class AbstractRequest implements ProvidesRequestData
 
 	private int $contentLength = 0;
 
-	private string $content;
+	private ?ComposesRequestContent $content;
 
 	/** @var array<string, mixed> */
 	private array $customVars = [];
@@ -50,10 +51,14 @@ abstract class AbstractRequest implements ProvidesRequestData
 	/** @var array<callable> */
 	private array $passThroughCallbacks = [];
 
-	public function __construct( string $scriptFilename, string $content )
+	public function __construct( string $scriptFilename, ?ComposesRequestContent $content = null )
 	{
 		$this->scriptFilename = $scriptFilename;
-		$this->setContent( $content );
+
+        if (null !== $content) {
+            $this->setContent( $content );
+            $this->setContentType( $content->getContentType() );
+        }
 	}
 
 	public function getServerSoftware() : string
@@ -136,15 +141,15 @@ abstract class AbstractRequest implements ProvidesRequestData
 		$this->contentType = $contentType;
 	}
 
-	public function getContent() : string
+	public function getContent() : ?ComposesRequestContent
 	{
 		return $this->content;
 	}
 
-	public function setContent( string $content ) : void
+	public function setContent( ComposesRequestContent $content ) : void
 	{
 		$this->content       = $content;
-		$this->contentLength = strlen( $content );
+		$this->contentLength = strlen( $content->getContent() );
 	}
 
 	/**

--- a/src/Requests/DeleteRequest.php
+++ b/src/Requests/DeleteRequest.php
@@ -3,7 +3,6 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\RequestMethod;
-use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 
 /**
  * Class DeleteRequest
@@ -11,17 +10,6 @@ use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
  */
 class DeleteRequest extends AbstractRequest
 {
-	public static function newWithRequestContent(
-		string $scriptFilename,
-		ComposesRequestContent $requestContent
-	) : DeleteRequest
-	{
-		$instance = new self( $scriptFilename, $requestContent->getContent() );
-		$instance->setContentType( $requestContent->getContentType() );
-
-		return $instance;
-	}
-
 	public function getRequestMethod() : string
 	{
 		return RequestMethod::DELETE;

--- a/src/Requests/GetRequest.php
+++ b/src/Requests/GetRequest.php
@@ -3,7 +3,6 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\RequestMethod;
-use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 
 /**
  * Class GetRequest
@@ -11,17 +10,6 @@ use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
  */
 class GetRequest extends AbstractRequest
 {
-	public static function newWithRequestContent(
-		string $scriptFilename,
-		ComposesRequestContent $requestContent
-	) : GetRequest
-	{
-		$instance = new self( $scriptFilename, $requestContent->getContent() );
-		$instance->setContentType( $requestContent->getContentType() );
-
-		return $instance;
-	}
-
 	public function getRequestMethod() : string
 	{
 		return RequestMethod::GET;

--- a/src/Requests/PatchRequest.php
+++ b/src/Requests/PatchRequest.php
@@ -3,7 +3,6 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\RequestMethod;
-use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 
 /**
  * Class PatchRequest
@@ -11,17 +10,6 @@ use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
  */
 class PatchRequest extends AbstractRequest
 {
-	public static function newWithRequestContent(
-		string $scriptFilename,
-		ComposesRequestContent $requestContent
-	) : PatchRequest
-	{
-		$instance = new self( $scriptFilename, $requestContent->getContent() );
-		$instance->setContentType( $requestContent->getContentType() );
-
-		return $instance;
-	}
-
 	public function getRequestMethod() : string
 	{
 		return RequestMethod::PATCH;

--- a/src/Requests/PostRequest.php
+++ b/src/Requests/PostRequest.php
@@ -3,7 +3,6 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\RequestMethod;
-use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 
 /**
  * Class PostRequest
@@ -11,17 +10,6 @@ use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
  */
 class PostRequest extends AbstractRequest
 {
-	public static function newWithRequestContent(
-		string $scriptFilename,
-		ComposesRequestContent $requestContent
-	) : PostRequest
-	{
-		$instance = new self( $scriptFilename, $requestContent->getContent() );
-		$instance->setContentType( $requestContent->getContentType() );
-
-		return $instance;
-	}
-
 	public function getRequestMethod() : string
 	{
 		return RequestMethod::POST;

--- a/src/Requests/PutRequest.php
+++ b/src/Requests/PutRequest.php
@@ -3,7 +3,6 @@
 namespace hollodotme\FastCGI\Requests;
 
 use hollodotme\FastCGI\Constants\RequestMethod;
-use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 
 /**
  * Class PutRequest
@@ -11,17 +10,6 @@ use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
  */
 class PutRequest extends AbstractRequest
 {
-	public static function newWithRequestContent(
-		string $scriptFilename,
-		ComposesRequestContent $requestContent
-	) : PutRequest
-	{
-		$instance = new self( $scriptFilename, $requestContent->getContent() );
-		$instance->setContentType( $requestContent->getContentType() );
-
-		return $instance;
-	}
-
 	public function getRequestMethod() : string
 	{
 		return RequestMethod::PUT;

--- a/src/Responses/Response.php
+++ b/src/Responses/Response.php
@@ -17,22 +17,18 @@ class Response implements ProvidesResponseData
 	private const HEADER_PATTERN = '#^([^\:]+):(.*)$#';
 
 	/** @var array<string, array<int, string>> */
-	private $normalizedHeaders;
+	private array $normalizedHeaders;
 
 	/** @var array<string, array<int, string>> */
-	private $headers;
+	private array $headers;
 
-	/** @var string */
-	private $body;
+	private string $body;
 
-	/** @var string */
-	private $output;
+	private string $output;
 
-	/** @var string */
-	private $error;
+	private string $error;
 
-	/** @var float */
-	private $duration;
+	private float $duration;
 
 	public function __construct( string $output, string $error, float $duration )
 	{

--- a/src/SocketConnections/NetworkSocket.php
+++ b/src/SocketConnections/NetworkSocket.php
@@ -6,17 +6,13 @@ use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
 
 class NetworkSocket implements ConfiguresSocketConnection
 {
-	/** @var string */
-	private $host;
+	private string $host;
 
-	/** @var int */
-	private $port;
+	private int $port;
 
-	/** @var int */
-	private $connectTimeout;
+	private int $connectTimeout;
 
-	/** @var int */
-	private $readWriteTimeout;
+	private int $readWriteTimeout;
 
 	public function __construct(
 		string $host,

--- a/src/SocketConnections/UnixDomainSocket.php
+++ b/src/SocketConnections/UnixDomainSocket.php
@@ -10,14 +10,11 @@ use hollodotme\FastCGI\Interfaces\ConfiguresSocketConnection;
  */
 class UnixDomainSocket implements ConfiguresSocketConnection
 {
-	/** @var string */
-	private $socketPath;
+	private string $socketPath;
 
-	/** @var int */
-	private $connectTimeout;
+	private int $connectTimeout;
 
-	/** @var int */
-	private $readWriteTimeout;
+	private int $readWriteTimeout;
 
 	public function __construct(
 		string $socketPath,

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -338,7 +338,7 @@ final class Socket
 
 		$requestPackets .= $this->packetEncoder->encodePacket( self::PARAMS, '', $this->id->getValue() );
 
-		if ( $request->getContent() )
+		if ( $request->getContent() !== null )
 		{
 			$offset = 0;
 			do
@@ -346,7 +346,7 @@ final class Socket
 				$requestPackets .= $this->packetEncoder->encodePacket(
 					self::STDIN,
 					substr(
-						$request->getContent(),
+						$request->getContent()->getContent(),
 						$offset,
 						self::REQ_MAX_CONTENT_SIZE
 					),

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -74,38 +74,31 @@ final class Socket
 
 	public const  STREAM_SELECT_USEC   = 200000;
 
-	/** @var SocketId */
-	private $id;
+	private SocketId $id;
 
-	/** @var ConfiguresSocketConnection */
-	private $connection;
+	private ConfiguresSocketConnection $connection;
 
 	/** @var null|resource */
 	private $resource;
 
-	/** @var EncodesPacket */
-	private $packetEncoder;
+	private EncodesPacket $packetEncoder;
 
-	/** @var EncodesNameValuePair */
-	private $nameValuePairEncoder;
+	private EncodesNameValuePair $nameValuePairEncoder;
 
 	/** @var callable[] */
-	private $responseCallbacks;
+	private array $responseCallbacks;
 
 	/** @var callable[] */
-	private $failureCallbacks;
+	private array $failureCallbacks;
 
 	/** @var callable[] */
-	private $passThroughCallbacks;
+	private array $passThroughCallbacks;
 
-	/** @var float */
-	private $startTime;
+	private float $startTime;
 
-	/** @var null|ProvidesResponseData */
-	private $response;
+	private ?ProvidesResponseData $response;
 
-	/** @var int */
-	private $status;
+	private int $status;
 
 	/**
 	 * @param SocketId                   $socketId

--- a/src/Sockets/SocketCollection.php
+++ b/src/Sockets/SocketCollection.php
@@ -15,7 +15,7 @@ use function count;
 final class SocketCollection implements Countable
 {
 	/** @var Socket[] */
-	private $sockets = [];
+	private array $sockets = [];
 
 	/**
 	 * @param ConfiguresSocketConnection $connection

--- a/src/Sockets/SocketId.php
+++ b/src/Sockets/SocketId.php
@@ -8,8 +8,7 @@ use function random_int;
 
 final class SocketId
 {
-	/** @var int */
-	private $id;
+	private int $id;
 
 	/**
 	 * @param int $id

--- a/tests/Integration/Async/AsyncRequestsTest.php
+++ b/tests/Integration/Async/AsyncRequestsTest.php
@@ -8,6 +8,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
@@ -16,7 +17,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Throwable;
-use function http_build_query;
 use function parse_ini_file;
 use function range;
 use function sort;
@@ -45,7 +45,7 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', '' );
+		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( &$results )
 			{
@@ -55,7 +55,7 @@ final class AsyncRequestsTest extends TestCase
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -105,7 +105,7 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', '' );
+		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( &$results )
 			{
@@ -115,7 +115,7 @@ final class AsyncRequestsTest extends TestCase
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}
@@ -161,11 +161,11 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', '' );
+		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -203,7 +203,7 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', '' );
+		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( &$results )
 			{
@@ -213,7 +213,7 @@ final class AsyncRequestsTest extends TestCase
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -9,6 +9,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\GetRequest;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\Defaults;
@@ -23,7 +24,6 @@ use ReflectionClass;
 use RuntimeException;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Throwable;
-use function http_build_query;
 use function preg_match;
 
 final class NetworkSocketTest extends TestCase
@@ -60,7 +60,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanSendAsyncRequestAndReceiveSocketId() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketId = $this->client->sendAsyncRequest( $this->connection, $request );
@@ -78,7 +78,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanSendAsyncRequestAndReadResponse() : void
 	{
-		$content          = http_build_query( ['test-key' => 'unit'] );
+		$content          = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request          = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 		$expectedResponse =
 			"X-Powered-By: PHP/7.1.0\r\nX-Custom: Header\r\nContent-type: text/html; charset=UTF-8\r\n\r\nunit";
@@ -100,7 +100,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanSendSyncRequestAndReceiveResponse() : void
 	{
-		$content          = http_build_query( ['test-key' => 'unit'] );
+		$content          = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request          = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 		$expectedResponse =
 			"X-Powered-By: PHP/7.1.0\r\nX-Custom: Header\r\nContent-type: text/html; charset=UTF-8\r\n\r\nunit";
@@ -122,7 +122,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanReceiveResponseInCallback() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -148,7 +148,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanHandleExceptionsInFailureCallback() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -182,7 +182,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanCheckForSocketIdsHavingResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketId = $this->client->sendAsyncRequest( $this->connection, $request );
@@ -201,12 +201,12 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanReadResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketIdOne = $this->client->sendAsyncRequest( $this->connection, $request );
 
-		$request->setContent( http_build_query( ['test-key' => 'test'] ) );
+		$request->setContent( new UrlEncodedFormData( ['test-key' => 'test'] ) );
 
 		$socketIdTwo = $this->client->sendAsyncRequest( $this->connection, $request );
 
@@ -240,14 +240,14 @@ final class NetworkSocketTest extends TestCase
 			Defaults::CONNECT_TIMEOUT,
 			100
 		);
-		$content    = http_build_query( ['test-key' => 'unit'] );
+		$content    = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request    = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), $content );
 
 		$response = $this->client->sendRequest( $connection, $request );
 
 		self::assertSame( 'unit - 0', $response->getBody() );
 
-		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), $content );
 
 		$this->expectException( TimedoutException::class );
@@ -265,7 +265,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanHandleReadyResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -293,7 +293,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanReadReadyResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$this->client->sendAsyncRequest( $this->connection, $request );
@@ -318,7 +318,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanWaitForResponse() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -345,7 +345,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testReadResponsesSkipsUnknownSocketIds() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketIds   = [];
@@ -379,7 +379,7 @@ final class NetworkSocketTest extends TestCase
 			'test-second-key' => 'test-second-key',
 			'test-third-key'  => str_repeat( 'test-third-key', 5000 ),
 		];
-		$content = http_build_query( $data );
+		$content = new UrlEncodedFormData( $data );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest    = $this;
@@ -480,7 +480,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testRequestingAnUnknownScriptPathThrowsException( string $scriptFilename ) : void
 	{
-		$request = new GetRequest( $scriptFilename, '' );
+		$request = new GetRequest( $scriptFilename );
 
 		$response = $this->client->sendRequest( $this->connection, $request );
 
@@ -528,7 +528,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testNotAllowedFileNameExtensionRespondsWithAccessDeniedHeader() : void
 	{
-		$request = new GetRequest( $this->getWorkerPath( 'worker.php7' ), '' );
+		$request = new GetRequest( $this->getWorkerPath( 'worker.php7' ) );
 
 		$response = $this->client->sendRequest( $this->connection, $request );
 
@@ -554,7 +554,7 @@ final class NetworkSocketTest extends TestCase
 
 		$this->makeFileUnaccessible( $scriptPath );
 
-		$request  = new GetRequest( $scriptPath, '' );
+		$request  = new GetRequest( $scriptPath );
 		$response = $this->client->sendRequest( $this->connection, $request );
 
 		$expectedStatus = [
@@ -606,7 +606,7 @@ final class NetworkSocketTest extends TestCase
 	{
 		$expectecOutputRegExp = "#^ERROR: Primary script unknown\n?$#";
 
-		$request = new GetRequest( '/not/existing.php', '' );
+		$request = new GetRequest( '/not/existing.php' );
 		$request->addPassThroughCallbacks(
 			static function (
 				/** @noinspection PhpUnusedParameterInspection */
@@ -637,7 +637,7 @@ final class NetworkSocketTest extends TestCase
 	{
 		$unitTest = $this;
 
-		$request = new GetRequest( '/not/existing.php', '' );
+		$request = new GetRequest( '/not/existing.php' );
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( $unitTest )
 			{
@@ -659,7 +659,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanGetErrorOutputFromWorkerUsingErrorLog() : void
 	{
-		$request  = new GetRequest( $this->getWorkerPath( 'errorLogWorker.php' ), '' );
+		$request  = new GetRequest( $this->getWorkerPath( 'errorLogWorker.php' ) );
 		$response = $this->client->sendRequest( $this->connection, $request );
 
 		$expectedError = "#^PHP message: ERROR1\n\n?"
@@ -681,7 +681,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testSuccessiveRequestsShouldUseSameSocket() : void
 	{
-		$request = new GetRequest( $this->getWorkerPath( 'sleepWorker.php' ), '' );
+		$request = new GetRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 
 		$sockets = (new ReflectionClass( $this->client ))->getProperty( 'sockets' );
 		$sockets->setAccessible( true );

--- a/tests/Integration/Signals/SignaledWorkersTest.php
+++ b/tests/Integration/Signals/SignaledWorkersTest.php
@@ -8,6 +8,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
@@ -18,7 +19,6 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Throwable;
 use function escapeshellarg;
 use function exec;
-use function http_build_query;
 use function preg_match;
 use function shell_exec;
 use function sleep;
@@ -50,7 +50,7 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnNetworkSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ), '' );
+		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ) );
 		$success  = [];
 		$failures = [];
 
@@ -70,7 +70,7 @@ final class SignaledWorkersTest extends TestCase
 
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -166,7 +166,7 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnUnixDomainSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ), '' );
+		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ) );
 		$success  = [];
 		$failures = [];
 
@@ -186,7 +186,7 @@ final class SignaledWorkersTest extends TestCase
 
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}
@@ -225,7 +225,7 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfAllProcessesGetInterruptedOnNetworkSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), '' );
+		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 		$success  = [];
 		$failures = [];
 
@@ -245,7 +245,7 @@ final class SignaledWorkersTest extends TestCase
 
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i, 'sleep' => 2] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 2] ) );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -302,7 +302,7 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfAllProcessesGetInterruptedOnUnixDomainSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), '' );
+		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 		$success  = [];
 		$failures = [];
 
@@ -322,7 +322,7 @@ final class SignaledWorkersTest extends TestCase
 
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( http_build_query( ['test-key' => $i, 'sleep' => 1] ) );
+			$request->setContent( new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 1] ) );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}
@@ -349,7 +349,7 @@ final class SignaledWorkersTest extends TestCase
 	public function testBrokenSocketGetsRemovedIfWritingRequestFailed() : void
 	{
 		$client     = new Client();
-		$request    = new PostRequest( $this->getWorkerPath( 'pidWorker.php' ), '' );
+		$request    = new PostRequest( $this->getWorkerPath( 'pidWorker.php' ) );
 		$connection = $this->getUnixDomainSocketConnection();
 
 		$socketId1 = $client->sendAsyncRequest( $connection, $request );

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -9,6 +9,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\GetRequest;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\Defaults;
@@ -61,7 +62,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanSendAsyncRequestAndReceiveSocketId() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketId = $this->client->sendAsyncRequest( $this->connection, $request );
@@ -79,7 +80,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanSendAsyncRequestAndReadResponse() : void
 	{
-		$content          = http_build_query( ['test-key' => 'unit'] );
+		$content          = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request          = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 		$expectedResponse =
 			"X-Powered-By: PHP/7.1.0\r\nX-Custom: Header\r\nContent-type: text/html; charset=UTF-8\r\n\r\nunit";
@@ -101,7 +102,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanSendSyncRequestAndReceiveResponse() : void
 	{
-		$content          = http_build_query( ['test-key' => 'unit'] );
+		$content          = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request          = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 		$expectedResponse =
 			"X-Powered-By: PHP/7.1.0\r\nX-Custom: Header\r\nContent-type: text/html; charset=UTF-8\r\n\r\nunit";
@@ -123,7 +124,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanReceiveResponseInCallback() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -149,7 +150,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanHandleExceptionsInFailureCallback() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -183,7 +184,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanCheckForSocketIdsHavingResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketId = $this->client->sendAsyncRequest( $this->connection, $request );
@@ -202,12 +203,12 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanReadResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketIdOne = $this->client->sendAsyncRequest( $this->connection, $request );
 
-		$request->setContent( http_build_query( ['test-key' => 'test'] ) );
+		$request->setContent( new UrlEncodedFormData( ['test-key' => 'test'] ) );
 
 		$socketIdTwo = $this->client->sendAsyncRequest( $this->connection, $request );
 
@@ -240,14 +241,14 @@ final class UnixDomainSocketTest extends TestCase
 			Defaults::CONNECT_TIMEOUT,
 			100
 		);
-		$content    = http_build_query( ['test-key' => 'unit'] );
+		$content    = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request    = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), $content );
 
 		$response = $this->client->sendRequest( $connection, $request );
 
 		self::assertSame( 'unit - 0', $response->getBody() );
 
-		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), $content );
 
 		$this->expectException( TimedoutException::class );
@@ -265,7 +266,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanHandleReadyResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -293,7 +294,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanReadReadyResponses() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$this->client->sendAsyncRequest( $this->connection, $request );
@@ -318,7 +319,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanWaitForResponse() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest = $this;
@@ -345,7 +346,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testReadResponsesSkipsUnknownSocketIds() : void
 	{
-		$content = http_build_query( ['test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['test-key' => 'unit'] );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$socketIds   = [];
@@ -379,7 +380,7 @@ final class UnixDomainSocketTest extends TestCase
 			'test-second-key' => 'test-second-key',
 			'test-third-key'  => str_repeat( 'test-third-key', 5000 ),
 		];
-		$content = http_build_query( $data );
+		$content = new UrlEncodedFormData( $data );
 		$request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
 
 		$unitTest    = $this;
@@ -477,7 +478,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testRequestingAnUnknownScriptPathThrowsException( string $scriptFilename ) : void
 	{
-		$request = new GetRequest( $scriptFilename, '' );
+		$request = new GetRequest( $scriptFilename );
 
 		$response = $this->client->sendRequest( $this->connection, $request );
 
@@ -512,7 +513,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testNotAllowedFileNameExtensionRespondsWithAccessDeniedHeader() : void
 	{
-		$request = new GetRequest( $this->getWorkerPath( 'worker.php7' ), '' );
+		$request = new GetRequest( $this->getWorkerPath( 'worker.php7' ) );
 
 		$response = $this->client->sendRequest( $this->connection, $request );
 
@@ -538,7 +539,7 @@ final class UnixDomainSocketTest extends TestCase
 
 		$this->makeFileUnaccessible( $scriptPath );
 
-		$request  = new GetRequest( $scriptPath, '' );
+		$request  = new GetRequest( $scriptPath );
 		$response = $this->client->sendRequest( $this->connection, $request );
 
 		$expectedStatus = [
@@ -590,7 +591,7 @@ final class UnixDomainSocketTest extends TestCase
 	{
 		$expectecOutputRegExp = "#^ERROR: Primary script unknown\n?$#";
 
-		$request = new GetRequest( '/not/existing.php', '' );
+		$request = new GetRequest( '/not/existing.php' );
 		$request->addPassThroughCallbacks(
 			static function (
 				/** @noinspection PhpUnusedParameterInspection */
@@ -621,7 +622,7 @@ final class UnixDomainSocketTest extends TestCase
 	{
 		$unitTest = $this;
 
-		$request = new GetRequest( '/not/existing.php', '' );
+		$request = new GetRequest( '/not/existing.php' );
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response ) use ( $unitTest )
 			{
@@ -643,7 +644,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanGetErrorOutputFromWorkerUsingErrorLog() : void
 	{
-		$request  = new GetRequest( $this->getWorkerPath( 'errorLogWorker.php' ), '' );
+		$request  = new GetRequest( $this->getWorkerPath( 'errorLogWorker.php' ) );
 		$response = $this->client->sendRequest( $this->connection, $request );
 
 		$expectedError = "#^PHP message: ERROR1\n\n?"
@@ -678,7 +679,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testSuccessiveRequestsShouldUseSameSocket() : void
 	{
-		$request = new GetRequest( $this->getWorkerPath( 'sleepWorker.php' ), '' );
+		$request = new GetRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 
 		$sockets = (new ReflectionClass( $this->client ))->getProperty( 'sockets' );
 		$sockets->setAccessible( true );

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -31,7 +31,7 @@ final class ClientTest extends TestCase
 	{
 		$connection = new UnixDomainSocket( $this->getNonExistingUnixDomainSocket() );
 		$client     = new Client();
-		$request    = new PostRequest( '/path/to/script.php', '' );
+		$request    = new PostRequest( '/path/to/script.php' );
 
 		$this->expectException( ConnectException::class );
 		$this->expectExceptionMessage( 'Unable to connect to FastCGI application: No such file or directory' );
@@ -53,7 +53,7 @@ final class ClientTest extends TestCase
 
 		$connection = new UnixDomainSocket( '' . $testSocket );
 		$client     = new Client();
-		$request    = new PostRequest( '/path/to/script.php', '' );
+		$request    = new PostRequest( '/path/to/script.php' );
 
 		$this->expectException( ConnectException::class );
 		$this->expectExceptionMessage( 'Unable to connect to FastCGI application: Connection refused' );
@@ -125,7 +125,7 @@ final class ClientTest extends TestCase
 	{
 		$connection = new UnixDomainSocket( $this->getRestrictedUnixDomainSocket() );
 		$client     = new Client();
-		$request    = new PostRequest( '/path/to/script.php', '' );
+		$request    = new PostRequest( '/path/to/script.php' );
 
 		$this->expectException( ConnectException::class );
 		$this->expectExceptionMessage( 'Unable to connect to FastCGI application: No such file or directory' );

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace hollodotme\FastCGI\Tests\Unit\Requests;
 
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\AbstractRequest;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
@@ -18,11 +19,11 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanGetDefaultValues( string $requestMethod ) : void
 	{
-		$request = $this->getRequest( $requestMethod, '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( $requestMethod, '/path/to/script.php');
 
 		self::assertSame( 'FastCGI/1.0', $request->getGatewayInterface() );
 		self::assertSame( '/path/to/script.php', $request->getScriptFilename() );
-		self::assertSame( 'Unit-Test', $request->getContent() );
+		self::assertSame( null, $request->getContent() );
 		self::assertSame( 9, $request->getContentLength() );
 		self::assertSame( '127.0.0.1', $request->getServerAddress() );
 		self::assertSame( 'localhost', $request->getServerName() );
@@ -44,15 +45,15 @@ final class AbstractRequestTest extends TestCase
 	 *
 	 * @return AbstractRequest
 	 */
-	private function getRequest( string $requestMethod, string $scriptFilename, string $content ) : AbstractRequest
+	private function getRequest( string $requestMethod, string $scriptFilename ) : AbstractRequest
 	{
-		return new class($requestMethod, $scriptFilename, $content) extends AbstractRequest {
+		return new class($requestMethod, $scriptFilename) extends AbstractRequest {
 			/** @var string */
 			private $requestMethod;
 
-			public function __construct( string $requestMethod, string $scriptFilename, string $content )
+			public function __construct( string $requestMethod, string $scriptFilename )
 			{
-				parent::__construct( $scriptFilename, $content );
+				parent::__construct( $scriptFilename );
 				$this->requestMethod = $requestMethod;
 			}
 
@@ -126,11 +127,11 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testContentLengthChangesWithContent() : void
 	{
-		$request = $this->getRequest( 'GET', '/path/to/script.php', 'Some content' );
+		$request = $this->getRequest( 'GET', '/path/to/script.php', new UrlEncodedFormData( ['test' => 'some content'] ) );
 
 		self::assertSame( 12, $request->getContentLength() );
 
-		$request->setContent( 'Some new content' );
+		$request->setContent( new UrlEncodedFormData( ['test' => 'some new content'] ) );
 
 		self::assertSame( 16, $request->getContentLength() );
 	}

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -189,7 +189,7 @@ final class SocketTest extends TestCase
 	public function testThrowsExceptionIfRequestIsSentToSocketThatIsNotIdle() : void
 	{
 		$socket  = $this->getSocket();
-		$request = new PostRequest( '/some/script.php', '' );
+		$request = new PostRequest( '/some/script.php' );
 
 		$socket->sendRequest( $request );
 


### PR DESCRIPTION
This branch started from https://github.com/hollodotme/fast-cgi-client/pull/70, so that should be reviewed first.

I've taken a crack at the following:

> Refactor the AbstractRequest class, so that it always expects a request content object by requiring the ComposesRequestContent interface for the $content property. This would make the named constructor newWithRequestContent(), that was introduced in v3.1.0, obsolete and should be less confusing how to compose the content of a request for users. See https://github.com/hollodotme/fast-cgi-client/issues/56

I hope I fully understood what you were trying to achieve with this and implemented it correctly.

While I was working on this it seemed only natural to also make the content parameter/property nullable, since that use case popped up a lot both in the examples, tests and [userland use-cases](https://github.com/gordalina/cachetool/blob/e3e6e79a265a67d834590c1d51de209d3e8620db/src/Adapter/FastCGI.php#L129). Sending a request with just a script file seemed like something that should be possible.

Obviously a BC break.

I couldn't get the tests to work locally, and the CI also seems to be crashing on something unrelated. Is it an option to simplify the whole docker/make set up for 4.x and install phpunit/phpstan as regular dev-dependencies through Composer?

