### PR TITLE
ComposesRequestContent->toString() and immutable request content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepa
 
 ## [4.0.0] - t.b.d
 
-* `AbstractRequest->setContent()` is removed. Making the request content immutable.
+* `AbstractRequest::content` now takes an instance of ComposesRequestContent. Strings can no longer be passed directly as content. Select one of the implementations: JsonData, MultipartFormData or UrlEncodedFormData, or create your own by implementing the interface.
+* `AbstractRequest::content` is now nullable. You can create a request with just a scriptFileName and no content.
+* `AbstractRequest->setContent()` is removed. Making the request content immutable once set in the constructor.
 
 
 ## [3.1.7] - 2021-12-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This project adheres
 to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [4.0.0] - t.b.d
+
+* `AbstractRequest->setContent()` is removed. Making the request content immutable.
+
+
 ## [3.1.7] - 2021-12-07
 
 * Make sure length values are within valid bounds

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ $urlEncodedContent = new UrlEncodedFormData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $urlEncodedContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $urlEncodedContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```
@@ -713,7 +713,7 @@ $multipartContent = new MultipartFormData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $multipartContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $multipartContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```
@@ -812,7 +812,7 @@ $jsonContent = new JsonData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $jsonContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $jsonContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```

--- a/bin/examples.php
+++ b/bin/examples.php
@@ -39,8 +39,6 @@ $connection = new UnixDomainSocket( '/var/run/php-uds.sock' );
 
 $workerPath = __DIR__ . '/exampleWorker.php';
 
-$request = new PostRequest( $workerPath );
-
 printLine( "\n" );
 printLine( 'hollodotme/fast-cgi-client examples', 'blue', true );
 printLine( 'Worker script: ' . $workerPath, 'blue' );
@@ -60,7 +58,7 @@ printLine( '# Sending one synchronous request... (worker sleeps 1 second)' );
 printLine( 'CODE: $client->sendRequest( $request );', 'red' );
 printLine( "\n" );
 
-$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single synchronous request'] ) );
+$request = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single synchronous request'] ) );
 
 sleep( 2 );
 
@@ -76,7 +74,7 @@ printLine( '# Sending one asynchronous request... (worker sleeps 1 second)' );
 printLine( 'CODE: $client->sendAsyncRequest( $request );', 'red' );
 printLine( "\n" );
 
-$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request'] ) );
+$request = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request'] ) );
 
 sleep( 2 );
 
@@ -110,7 +108,7 @@ printLine( '        }', 'red' );
 printLine( '      );', 'red' );
 printLine( "\n" );
 
-$request->setContent( new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request with callback'] ) );
+$request = new PostRequest( $workerPath, new UrlEncodedFormData( ['sleep' => 1, 'key' => 'single asynchronous request with callback'] ) );
 $request->addResponseCallbacks(
 	static function ( ProvidesResponseData $response )
 	{

--- a/src/Interfaces/ComposesRequestContent.php
+++ b/src/Interfaces/ComposesRequestContent.php
@@ -6,5 +6,5 @@ interface ComposesRequestContent
 {
 	public function getContentType() : string;
 
-	public function getContent() : string;
+	public function toString() : string;
 }

--- a/src/RequestContents/JsonData.php
+++ b/src/RequestContents/JsonData.php
@@ -37,7 +37,7 @@ final class JsonData implements ComposesRequestContent
 	 * @return string
 	 * @throws RuntimeException
 	 */
-	public function getContent() : string
+	public function toString() : string
 	{
 		$json = json_encode( $this->data, $this->encodingOptions, $this->encodingDepth );
 

--- a/src/RequestContents/MultipartFormData.php
+++ b/src/RequestContents/MultipartFormData.php
@@ -63,7 +63,7 @@ final class MultipartFormData implements ComposesRequestContent
 		return 'multipart/form-data; boundary=' . self::BOUNDARY_ID;
 	}
 
-	public function getContent() : string
+	public function toString() : string
 	{
 		$data = [];
 

--- a/src/RequestContents/UrlEncodedFormData.php
+++ b/src/RequestContents/UrlEncodedFormData.php
@@ -23,7 +23,7 @@ final class UrlEncodedFormData implements ComposesRequestContent
 		return 'application/x-www-form-urlencoded';
 	}
 
-	public function getContent() : string
+	public function toString() : string
 	{
 		return http_build_query( $this->formData );
 	}

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -33,8 +33,6 @@ abstract class AbstractRequest implements ProvidesRequestData
 
 	private string $contentType = 'application/x-www-form-urlencoded';
 
-	private int $contentLength = 0;
-
 	private ?ComposesRequestContent $content;
 
 	/** @var array<string, mixed> */
@@ -57,8 +55,7 @@ abstract class AbstractRequest implements ProvidesRequestData
         $this->content = $content;
 
         if (null !== $content) {
-            $this->contentLength = strlen( $content->getContent() );
-            $this->setContentType( $content->getContentType() );
+            $this->contentType = $content->getContentType();
         }
 	}
 
@@ -132,11 +129,6 @@ abstract class AbstractRequest implements ProvidesRequestData
 		$this->serverProtocol = $serverProtocol;
 	}
 
-	public function getContentType() : string
-	{
-		return $this->contentType;
-	}
-
 	public function setContentType( string $contentType ) : void
 	{
 		$this->contentType = $contentType;
@@ -147,17 +139,17 @@ abstract class AbstractRequest implements ProvidesRequestData
 		return $this->content;
 	}
 
-	public function setContent( ComposesRequestContent $content ) : void
-	{
-        $this->content = $content;
-		$this->contentLength = strlen( $content->getContent() );
-	}
+    public function getContentLength() : int
+    {
+        return $this->content ? strlen($this->content->toString()) : 0;
+    }
 
-	/**
-	 * @param string $key
-	 * @param mixed  $value
-	 */
-	public function setCustomVar( string $key, $value ) : void
+    public function getContentType() : string
+    {
+        return $this->contentType;
+    }
+
+	public function setCustomVar( string $key, mixed $value ) : void
 	{
 		$this->customVars[ $key ] = $value;
 	}
@@ -191,11 +183,6 @@ abstract class AbstractRequest implements ProvidesRequestData
 	public function getScriptFilename() : string
 	{
 		return $this->scriptFilename;
-	}
-
-	public function getContentLength() : int
-	{
-		return $this->contentLength;
 	}
 
 	/**

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -54,9 +54,10 @@ abstract class AbstractRequest implements ProvidesRequestData
 	public function __construct( string $scriptFilename, ?ComposesRequestContent $content = null )
 	{
 		$this->scriptFilename = $scriptFilename;
+        $this->content = $content;
 
         if (null !== $content) {
-            $this->setContent( $content );
+            $this->contentLength = strlen( $content->getContent() );
             $this->setContentType( $content->getContentType() );
         }
 	}
@@ -148,7 +149,7 @@ abstract class AbstractRequest implements ProvidesRequestData
 
 	public function setContent( ComposesRequestContent $content ) : void
 	{
-		$this->content       = $content;
+        $this->content = $content;
 		$this->contentLength = strlen( $content->getContent() );
 	}
 

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -346,7 +346,7 @@ final class Socket
 				$requestPackets .= $this->packetEncoder->encodePacket(
 					self::STDIN,
 					substr(
-						$request->getContent()->getContent(),
+						$request->getContent()->toString(),
 						$offset,
 						self::REQ_MAX_CONTENT_SIZE
 					),

--- a/tests/Integration/Async/AsyncRequestsTest.php
+++ b/tests/Integration/Async/AsyncRequestsTest.php
@@ -45,17 +45,17 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$results )
-			{
-				$results[] = (int)$response->getBody();
-			}
-		);
+
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$results )
+                {
+                    $results[] = (int)$response->getBody();
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -105,17 +105,15 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$results )
-			{
-				$results[] = (int)$response->getBody();
-			}
-		);
-
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$results )
+                {
+                    $results[] = (int)$response->getBody();
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}
@@ -161,11 +159,10 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', new UrlEncodedFormData( ['test-key' => $i] ) );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -203,17 +200,17 @@ final class AsyncRequestsTest extends TestCase
 		$results         = [];
 		$expectedResults = range( 0, $limit - 1 );
 
-		$request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php' );
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$results )
-			{
-				$results[] = (int)$response->getBody();
-			}
-		);
+
 
 		for ( $i = 0; $i < $limit; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request = new PostRequest( dirname( __DIR__ ) . '/Workers/worker.php', new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$results )
+                {
+                    $results[] = (int)$response->getBody();
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}

--- a/tests/Integration/FileUpload/FileUploadTest.php
+++ b/tests/Integration/FileUpload/FileUploadTest.php
@@ -61,7 +61,7 @@ final class FileUploadTest extends TestCase
 		];
 
 		$multipartFormData = new MultipartFormData( $formData, $files );
-		$postRequest       = PostRequest::newWithRequestContent(
+		$postRequest       = new PostRequest(
 			dirname( __DIR__ ) . '/Workers/fileUploadWorker.php',
 			$multipartFormData
 		);

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -206,7 +206,7 @@ final class NetworkSocketTest extends TestCase
 
 		$socketIdOne = $this->client->sendAsyncRequest( $this->connection, $request );
 
-		$request->setContent( new UrlEncodedFormData( ['test-key' => 'test'] ) );
+        $request = new PostRequest( $this->getWorkerPath( 'worker.php' ), new UrlEncodedFormData( ['test-key' => 'test'] ) );
 
 		$socketIdTwo = $this->client->sendAsyncRequest( $this->connection, $request );
 

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -418,7 +418,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanGetLengthOfSentContent( int $length ) : void
 	{
-		$content = str_repeat( 'a', $length );
+        $content = new UrlEncodedFormData(['test' => str_repeat( 'a', $length )]);
 		$request = new PostRequest( $this->getWorkerPath( 'lengthWorker.php' ), $content );
 		$request->setContentType( '*/*' );
 		$result = $this->client->sendRequest( $this->connection, $request );

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -423,7 +423,7 @@ final class NetworkSocketTest extends TestCase
 		$request->setContentType( '*/*' );
 		$result = $this->client->sendRequest( $this->connection, $request );
 
-		self::assertEquals( $length, $result->getBody() );
+		self::assertEquals( $length + 5, $result->getBody() );
 	}
 
 	/**

--- a/tests/Integration/Signals/SignaledWorkersTest.php
+++ b/tests/Integration/Signals/SignaledWorkersTest.php
@@ -50,27 +50,25 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnNetworkSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ) );
 		$success  = [];
 		$failures = [];
 
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$success )
-			{
-				$success[] = (int)$response->getBody();
-			}
-		);
-
-		$request->addFailureCallbacks(
-			static function ( Throwable $e ) use ( &$failures )
-			{
-				$failures[] = $e;
-			}
-		);
-
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request  = new PostRequest( $this->getWorkerPath( 'worker.php'), new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$success )
+                {
+                    $success[] = (int)$response->getBody();
+                }
+            );
+
+            $request->addFailureCallbacks(
+                static function ( Throwable $e ) use ( &$failures )
+                {
+                    $failures[] = $e;
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -166,27 +164,25 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfOneProcessGetsInterruptedOnUnixDomainSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'worker.php' ) );
 		$success  = [];
 		$failures = [];
 
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$success )
-			{
-				$success[] = (int)$response->getBody();
-			}
-		);
-
-		$request->addFailureCallbacks(
-			static function ( Throwable $e ) use ( &$failures )
-			{
-				$failures[] = $e;
-			}
-		);
-
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request  = new PostRequest( $this->getWorkerPath( 'worker.php' ), new UrlEncodedFormData( ['test-key' => $i] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$success )
+                {
+                    $success[] = (int)$response->getBody();
+                }
+            );
+
+            $request->addFailureCallbacks(
+                static function ( Throwable $e ) use ( &$failures )
+                {
+                    $failures[] = $e;
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}
@@ -225,27 +221,25 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfAllProcessesGetInterruptedOnNetworkSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 		$success  = [];
 		$failures = [];
 
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$success )
-			{
-				$success[] = (int)$response->getBody();
-			}
-		);
-
-		$request->addFailureCallbacks(
-			static function ( Throwable $e ) use ( &$failures )
-			{
-				$failures[] = $e;
-			}
-		);
-
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 2] ) );
+            $request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ), new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 2]) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$success )
+                {
+                    $success[] = (int)$response->getBody();
+                }
+            );
+
+            $request->addFailureCallbacks(
+                static function ( Throwable $e ) use ( &$failures )
+                {
+                    $failures[] = $e;
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getNetworkSocketConnection(), $request );
 		}
@@ -302,27 +296,25 @@ final class SignaledWorkersTest extends TestCase
 	public function testFailureCallbackGetsCalledIfAllProcessesGetInterruptedOnUnixDomainSocket( int $signal ) : void
 	{
 		$client   = new Client();
-		$request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ) );
 		$success  = [];
 		$failures = [];
 
-		$request->addResponseCallbacks(
-			static function ( ProvidesResponseData $response ) use ( &$success )
-			{
-				$success[] = (int)$response->getBody();
-			}
-		);
-
-		$request->addFailureCallbacks(
-			static function ( Throwable $e ) use ( &$failures )
-			{
-				$failures[] = $e;
-			}
-		);
-
 		for ( $i = 0; $i < 3; $i++ )
 		{
-			$request->setContent( new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 1] ) );
+            $request  = new PostRequest( $this->getWorkerPath( 'sleepWorker.php' ),  new UrlEncodedFormData( ['test-key' => $i, 'sleep' => 1] ) );
+            $request->addResponseCallbacks(
+                static function ( ProvidesResponseData $response ) use ( &$success )
+                {
+                    $success[] = (int)$response->getBody();
+                }
+            );
+
+            $request->addFailureCallbacks(
+                static function ( Throwable $e ) use ( &$failures )
+                {
+                    $failures[] = $e;
+                }
+            );
 
 			$client->sendAsyncRequest( $this->getUnixDomainSocketConnection(), $request );
 		}

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -208,7 +208,7 @@ final class UnixDomainSocketTest extends TestCase
 
 		$socketIdOne = $this->client->sendAsyncRequest( $this->connection, $request );
 
-		$request->setContent( new UrlEncodedFormData( ['test-key' => 'test'] ) );
+        $request = new PostRequest( $this->getWorkerPath( 'worker.php' ), new UrlEncodedFormData( ['test-key' => 'test'] ) );
 
 		$socketIdTwo = $this->client->sendAsyncRequest( $this->connection, $request );
 

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -419,7 +419,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanGetLengthOfSentContent( int $length ) : void
 	{
-		$content = str_repeat( 'a', $length );
+		$content = new UrlEncodedFormData(['test' => str_repeat( 'a', $length )]);
 		$request = new PostRequest( $this->getWorkerPath( 'lengthWorker.php' ), $content );
 
 		$response = $this->client->sendRequest( $this->connection, $request );

--- a/tests/Unit/RequestContents/JsonDataTest.php
+++ b/tests/Unit/RequestContents/JsonDataTest.php
@@ -31,7 +31,7 @@ final class JsonDataTest extends TestCase
 	 */
 	public function testGetContentType( $data, string $expectedContent ) : void
 	{
-		self::assertSame( $expectedContent, (new JsonData( $data ))->getContent() );
+		self::assertSame( $expectedContent, (new JsonData( $data ))->toString() );
 	}
 
 	/**
@@ -71,6 +71,6 @@ final class JsonDataTest extends TestCase
 
 		$data = ['unit' => ['test' => ['level' => ['three' => ['and' => ['more']]]]]];
 
-		self::assertSame( '', (new JsonData( $data, 0, 3 ))->getContent() );
+		self::assertSame( '', (new JsonData( $data, 0, 3 ))->toString() );
 	}
 }

--- a/tests/Unit/RequestContents/MultipartFormDataTest.php
+++ b/tests/Unit/RequestContents/MultipartFormDataTest.php
@@ -36,7 +36,7 @@ final class MultipartFormDataTest extends TestCase
 		                   . file_get_contents( __DIR__ . '/_files/php-logo.png' ) . "\r\n"
 		                   . "--__X_FASTCGI_CLIENT_BOUNDARY__--\r\n\r\n";
 
-		self::assertSame( $expectedContent, $multipartFormData->getContent() );
+		self::assertSame( $expectedContent, $multipartFormData->toString() );
 	}
 
 	/**
@@ -67,7 +67,7 @@ final class MultipartFormDataTest extends TestCase
 		                   . file_get_contents( __DIR__ . '/_files/php-logo.png' ) . "\r\n"
 		                   . "--__X_FASTCGI_CLIENT_BOUNDARY__--\r\n\r\n";
 
-		self::assertSame( $expectedContent, $multipartFormData->getContent() );
+		self::assertSame( $expectedContent, $multipartFormData->toString() );
 	}
 
 	public function testConstructorThrowsExceptionIfFileDoesNotExist() : void

--- a/tests/Unit/RequestContents/UrlEncodedFormDataTest.php
+++ b/tests/Unit/RequestContents/UrlEncodedFormDataTest.php
@@ -27,6 +27,6 @@ final class UrlEncodedFormDataTest extends TestCase
 		$formData        = ['unit' => 'test', 'test' => 'unit'];
 		$expectedContent = 'unit=test&test=unit';
 
-		self::assertSame( $expectedContent, (new UrlEncodedFormData( $formData ))->getContent() );
+		self::assertSame( $expectedContent, (new UrlEncodedFormData( $formData ))->toString() );
 	}
 }

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -124,21 +124,6 @@ final class AbstractRequestTest extends TestCase
 	 * @throws ExpectationFailedException
 	 * @throws InvalidArgumentException
 	 */
-	public function testContentLengthChangesWithContent() : void
-	{
-		$request = $this->getRequest( 'GET', '/path/to/script.php', new UrlEncodedFormData( ['test' => 'some content'] ) );
-
-		self::assertSame( 12, $request->getContentLength() );
-
-		$request->setContent( new UrlEncodedFormData( ['test' => 'some new content'] ) );
-
-		self::assertSame( 16, $request->getContentLength() );
-	}
-
-	/**
-	 * @throws ExpectationFailedException
-	 * @throws InvalidArgumentException
-	 */
 	public function testCanOverwriteVars() : void
 	{
 		$request = $this->getRequest( 'POST', '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace hollodotme\FastCGI\Tests\Unit\Requests;
 
+use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\AbstractRequest;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -41,19 +42,17 @@ final class AbstractRequestTest extends TestCase
 	/**
 	 * @param string $requestMethod
 	 * @param string $scriptFilename
-	 * @param string $content
 	 *
 	 * @return AbstractRequest
 	 */
-	private function getRequest( string $requestMethod, string $scriptFilename ) : AbstractRequest
+	private function getRequest( string $requestMethod, string $scriptFilename, ?ComposesRequestContent $content = null ) : AbstractRequest
 	{
-		return new class($requestMethod, $scriptFilename) extends AbstractRequest {
-			/** @var string */
-			private $requestMethod;
+		return new class($requestMethod, $scriptFilename, $content) extends AbstractRequest {
+			private string $requestMethod;
 
-			public function __construct( string $requestMethod, string $scriptFilename )
+			public function __construct( string $requestMethod, string $scriptFilename, ?ComposesRequestContent $content = null )
 			{
-				parent::__construct( $scriptFilename );
+				parent::__construct( $scriptFilename, $content );
 				$this->requestMethod = $requestMethod;
 			}
 
@@ -97,7 +96,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanGetParametersArray( string $requestMethod ) : void
 	{
-		$request = $this->getRequest( $requestMethod, '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( $requestMethod, '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setCustomVar( 'UNIT', 'Test' );
 		$request->setRequestUri( '/unit/test/' );
 
@@ -142,7 +141,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanOverwriteVars() : void
 	{
-		$request = $this->getRequest( 'POST', '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( 'POST', '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setRemoteAddress( '10.100.10.1' );
 		$request->setRemotePort( 8599 );
 		$request->setServerSoftware( 'unit/test' );
@@ -185,7 +184,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanResetCustomVars() : void
 	{
-		$request = $this->getRequest( 'POST', '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( 'POST', '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setCustomVar( 'UNIT', 'Test' );
 
 		self::assertSame( ['UNIT' => 'Test'], $request->getCustomVars() );

--- a/tests/Unit/Requests/DeleteRequestTest.php
+++ b/tests/Unit/Requests/DeleteRequestTest.php
@@ -34,7 +34,7 @@ final class DeleteRequestTest extends TestCase
 			]
 		);
 
-		$request = DeleteRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new DeleteRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/DeleteRequestTest.php
+++ b/tests/Unit/Requests/DeleteRequestTest.php
@@ -16,7 +16,7 @@ final class DeleteRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new DeleteRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new DeleteRequest( '/path/to/script.php' );
 
 		self::assertSame( 'DELETE', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/GetRequestTest.php
+++ b/tests/Unit/Requests/GetRequestTest.php
@@ -34,7 +34,7 @@ final class GetRequestTest extends TestCase
 			]
 		);
 
-		$request = GetRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new GetRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/GetRequestTest.php
+++ b/tests/Unit/Requests/GetRequestTest.php
@@ -16,7 +16,7 @@ final class GetRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new GetRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new GetRequest( '/path/to/script.php' );
 
 		self::assertSame( 'GET', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PatchRequestTest.php
+++ b/tests/Unit/Requests/PatchRequestTest.php
@@ -16,7 +16,7 @@ final class PatchRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new PatchRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PatchRequest( '/path/to/script.php' );
 
 		self::assertSame( 'PATCH', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PatchRequestTest.php
+++ b/tests/Unit/Requests/PatchRequestTest.php
@@ -34,7 +34,7 @@ final class PatchRequestTest extends TestCase
 			]
 		);
 
-		$request = PatchRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PatchRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/PostRequestTest.php
+++ b/tests/Unit/Requests/PostRequestTest.php
@@ -16,7 +16,7 @@ final class PostRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsPost() : void
 	{
-		$request = new PostRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PostRequest( '/path/to/script.php' );
 
 		self::assertSame( 'POST', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PostRequestTest.php
+++ b/tests/Unit/Requests/PostRequestTest.php
@@ -34,7 +34,7 @@ final class PostRequestTest extends TestCase
 			]
 		);
 
-		$request = PostRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PostRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/PutRequestTest.php
+++ b/tests/Unit/Requests/PutRequestTest.php
@@ -16,7 +16,7 @@ final class PutRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsPut() : void
 	{
-		$request = new PutRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PutRequest( '/path/to/script.php' );
 
 		self::assertSame( 'PUT', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PutRequestTest.php
+++ b/tests/Unit/Requests/PutRequestTest.php
@@ -34,7 +34,7 @@ final class PutRequestTest extends TestCase
 			]
 		);
 
-		$request = PutRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PutRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Sockets/SocketCollectionTest.php
+++ b/tests/Unit/Sockets/SocketCollectionTest.php
@@ -246,9 +246,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$request = new PostRequest(
-			dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php',
-			''
-		);
+			dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php' );
 		$socket->sendRequest( $request );
 
 		/** @noinspection UnusedFunctionResultInspection */
@@ -281,7 +279,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$socket->sendRequest(
-			new PostRequest( '/some/script.php', '' )
+			new PostRequest( '/some/script.php' )
 		);
 
 		self::assertNull( $this->collection->getIdleSocket( $connection ) );
@@ -487,7 +485,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$socket->sendRequest(
-			new PostRequest( '/some/sctipt.php', '' )
+			new PostRequest( '/some/sctipt.php' )
 		);
 
 		self::assertTrue( $this->collection->hasBusySockets() );

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -10,6 +10,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\Defaults;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
@@ -79,7 +80,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 
 		$socket->sendRequest( $request );
@@ -108,7 +109,7 @@ final class SocketTest extends TestCase
 		$data      = ['test-key' => 'unit'];
 		$request   = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 
 		$socket->collectResource( $resources );
@@ -135,7 +136,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response )
@@ -163,7 +164,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 		$request->addFailureCallbacks(
 			static function ( Throwable $throwable )
@@ -284,7 +285,7 @@ final class SocketTest extends TestCase
 	public function testIsNotUsableWhenTimedOut() : void
 	{
 		$socket  = $this->getSocket();
-		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php', $content );
 		$socket->sendRequest( $request );
 


### PR DESCRIPTION
Branch started from https://github.com/hollodotme/fast-cgi-client/pull/74.

2 API improvements with a BC break:
* `AbstractRequest->setContent` is removed, making the content of a request immutable. Content can only be defined when creating the request, through the constructor. The script filename was already like this, and having both of them immutable results in a more resilient request object.
* `ComposesRequestContent->getContent` renamed to `toString`, see:
    * The old method name was confusing in the context of a request already having content, which ended up looking like: $request->getContent()->getContent(); `toString` better illustrates what this method does, which is return a string representation of the request content. 
