### PR TITLE
Configurable stream select

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ $urlEncodedContent = new UrlEncodedFormData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $urlEncodedContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $urlEncodedContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```
@@ -713,7 +713,7 @@ $multipartContent = new MultipartFormData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $multipartContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $multipartContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```
@@ -812,7 +812,7 @@ $jsonContent = new JsonData(
 	]
 );
 
-$postRequest = PostRequest::newWithRequestContent( '/path/to/target/script.php', $jsonContent );
+$postRequest = new PostRequest( '/path/to/target/script.php', $jsonContent );
 
 $response = $client->sendRequest( $connection, $postRequest );
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -191,22 +191,7 @@ class Client
 	 */
 	public function getSocketIdsHavingResponse() : array
 	{
-		if ( $this->sockets->isEmpty() )
-		{
-			return [];
-		}
-
-		$reads  = $this->sockets->collectResources();
-		$writes = $excepts = null;
-
-		$result = @stream_select( $reads, $writes, $excepts, 0, Socket::STREAM_SELECT_USEC );
-
-		if ( false === $result || 0 === count( $reads ) )
-		{
-			return [];
-		}
-
-		return $this->sockets->getSocketIdsByResources( $reads );
+        return $this->sockets->hasResponses();
 	}
 
 	/**

--- a/src/Interfaces/ProvidesRequestData.php
+++ b/src/Interfaces/ProvidesRequestData.php
@@ -34,6 +34,8 @@ interface ProvidesRequestData
 
 	public function getContent() : ?ComposesRequestContent;
 
+    public function getPollingTimeout() : ?int;
+
 	/**
 	 * @return array<string, mixed>
 	 */

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -35,6 +35,8 @@ abstract class AbstractRequest implements ProvidesRequestData
 
 	private int $contentLength = 0;
 
+    private ?int $pollingTimeout = null;
+
 	private ?ComposesRequestContent $content;
 
 	/** @var array<string, mixed> */
@@ -197,6 +199,16 @@ abstract class AbstractRequest implements ProvidesRequestData
 	{
 		return $this->contentLength;
 	}
+
+    public function getPollingTimeout(): ?int
+    {
+        return $this->pollingTimeout;
+    }
+
+    public function setPollingTimeout(int $pollingTimeout): void
+    {
+        $this->pollingTimeout = $pollingTimeout;
+    }
 
 	/**
 	 * @return array<string, mixed>

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -54,9 +54,10 @@ abstract class AbstractRequest implements ProvidesRequestData
 	public function __construct( string $scriptFilename, ?ComposesRequestContent $content = null )
 	{
 		$this->scriptFilename = $scriptFilename;
+        $this->content = $content;
 
         if (null !== $content) {
-            $this->setContent( $content );
+            $this->contentLength = strlen( $content->getContent() );
             $this->setContentType( $content->getContentType() );
         }
 	}
@@ -148,7 +149,7 @@ abstract class AbstractRequest implements ProvidesRequestData
 
 	public function setContent( ComposesRequestContent $content ) : void
 	{
-		$this->content       = $content;
+        $this->content = $content;
 		$this->contentLength = strlen( $content->getContent() );
 	}
 

--- a/src/Sockets/Socket.php
+++ b/src/Sockets/Socket.php
@@ -100,6 +100,8 @@ final class Socket
 
 	private int $status;
 
+    private int $pollingTimeout;
+
 	/**
 	 * @param SocketId                   $socketId
 	 * @param ConfiguresSocketConnection $connection
@@ -145,7 +147,7 @@ final class Socket
 		$reads  = [$this->resource];
 		$writes = $excepts = null;
 
-		return (bool)stream_select( $reads, $writes, $excepts, 0, self::STREAM_SELECT_USEC );
+		return (bool)stream_select( $reads, $writes, $excepts, 0, $this->pollingTimeout );
 	}
 
 	/**
@@ -161,6 +163,7 @@ final class Socket
 
 		$this->response = null;
 
+        $this->pollingTimeout       = $request->getPollingTimeout() ?? self::STREAM_SELECT_USEC;
 		$this->responseCallbacks    = $request->getResponseCallbacks();
 		$this->failureCallbacks     = $request->getFailureCallbacks();
 		$this->passThroughCallbacks = $request->getPassThroughCallbacks();

--- a/src/Sockets/SocketCollection.php
+++ b/src/Sockets/SocketCollection.php
@@ -199,4 +199,23 @@ final class SocketCollection implements Countable
 	{
 		return [] === $this->sockets;
 	}
+
+    /** @return array<int> */
+    public function hasResponses() : array
+    {
+        if ( $this->isEmpty() )
+        {
+            return [];
+        }
+
+        foreach ( $this->sockets as $socket )
+        {
+            if ( $socket->hasResponse() )
+            {
+                $socketIds[] = $socket->getId();
+            }
+        }
+
+        return $socketIds ?? [];
+    }
 }

--- a/tests/Integration/FileUpload/FileUploadTest.php
+++ b/tests/Integration/FileUpload/FileUploadTest.php
@@ -61,7 +61,7 @@ final class FileUploadTest extends TestCase
 		];
 
 		$multipartFormData = new MultipartFormData( $formData, $files );
-		$postRequest       = PostRequest::newWithRequestContent(
+		$postRequest       = new PostRequest(
 			dirname( __DIR__ ) . '/Workers/fileUploadWorker.php',
 			$multipartFormData
 		);

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -418,7 +418,7 @@ final class NetworkSocketTest extends TestCase
 	 */
 	public function testCanGetLengthOfSentContent( int $length ) : void
 	{
-		$content = str_repeat( 'a', $length );
+        $content = new UrlEncodedFormData(['test' => str_repeat( 'a', $length )]);
 		$request = new PostRequest( $this->getWorkerPath( 'lengthWorker.php' ), $content );
 		$request->setContentType( '*/*' );
 		$result = $this->client->sendRequest( $this->connection, $request );

--- a/tests/Integration/NetworkSocket/NetworkSocketTest.php
+++ b/tests/Integration/NetworkSocket/NetworkSocketTest.php
@@ -423,7 +423,7 @@ final class NetworkSocketTest extends TestCase
 		$request->setContentType( '*/*' );
 		$result = $this->client->sendRequest( $this->connection, $request );
 
-		self::assertEquals( $length, $result->getBody() );
+		self::assertEquals( $length + 5, $result->getBody() );
 	}
 
 	/**

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -704,4 +704,22 @@ final class UnixDomainSocketTest extends TestCase
 		self::assertSame( $firstSocket, $lastSocket );
 		self::assertCount( 1, $sockets->getValue( $this->client ) );
 	}
+
+    /**
+     * @throws Exception
+     * @throws ConnectException
+     * @throws TimedoutException
+     * @throws WriteFailedException
+     */
+    public function testSetCustomPollingTimeout() : void
+    {
+        $content = new UrlEncodedFormData( ['test-key' => 'unit'] );
+        $request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
+        $request->setPollingTimeout(500000);
+
+        $socketId = $this->client->sendAsyncRequest( $this->connection, $request );
+
+
+        self::assertEquals( $socketId, 500000 );
+    }
 }

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -419,7 +419,7 @@ final class UnixDomainSocketTest extends TestCase
 	 */
 	public function testCanGetLengthOfSentContent( int $length ) : void
 	{
-		$content = str_repeat( 'a', $length );
+		$content = new UrlEncodedFormData(['test' => str_repeat( 'a', $length )]);
 		$request = new PostRequest( $this->getWorkerPath( 'lengthWorker.php' ), $content );
 
 		$response = $this->client->sendRequest( $this->connection, $request );

--- a/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
+++ b/tests/Integration/UnixDomainSocket/UnixDomainSocketTest.php
@@ -704,22 +704,4 @@ final class UnixDomainSocketTest extends TestCase
 		self::assertSame( $firstSocket, $lastSocket );
 		self::assertCount( 1, $sockets->getValue( $this->client ) );
 	}
-
-    /**
-     * @throws Exception
-     * @throws ConnectException
-     * @throws TimedoutException
-     * @throws WriteFailedException
-     */
-    public function testSetCustomPollingTimeout() : void
-    {
-        $content = new UrlEncodedFormData( ['test-key' => 'unit'] );
-        $request = new PostRequest( $this->getWorkerPath( 'worker.php' ), $content );
-        $request->setPollingTimeout(500000);
-
-        $socketId = $this->client->sendAsyncRequest( $this->connection, $request );
-
-
-        self::assertEquals( $socketId, 500000 );
-    }
 }

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace hollodotme\FastCGI\Tests\Unit\Requests;
 
+use hollodotme\FastCGI\Interfaces\ComposesRequestContent;
 use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\AbstractRequest;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -41,19 +42,17 @@ final class AbstractRequestTest extends TestCase
 	/**
 	 * @param string $requestMethod
 	 * @param string $scriptFilename
-	 * @param string $content
 	 *
 	 * @return AbstractRequest
 	 */
-	private function getRequest( string $requestMethod, string $scriptFilename ) : AbstractRequest
+	private function getRequest( string $requestMethod, string $scriptFilename, ?ComposesRequestContent $content = null ) : AbstractRequest
 	{
-		return new class($requestMethod, $scriptFilename) extends AbstractRequest {
-			/** @var string */
-			private $requestMethod;
+		return new class($requestMethod, $scriptFilename, $content) extends AbstractRequest {
+			private string $requestMethod;
 
-			public function __construct( string $requestMethod, string $scriptFilename )
+			public function __construct( string $requestMethod, string $scriptFilename, ?ComposesRequestContent $content = null )
 			{
-				parent::__construct( $scriptFilename );
+				parent::__construct( $scriptFilename, $content );
 				$this->requestMethod = $requestMethod;
 			}
 
@@ -97,7 +96,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanGetParametersArray( string $requestMethod ) : void
 	{
-		$request = $this->getRequest( $requestMethod, '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( $requestMethod, '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setCustomVar( 'UNIT', 'Test' );
 		$request->setRequestUri( '/unit/test/' );
 
@@ -142,7 +141,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanOverwriteVars() : void
 	{
-		$request = $this->getRequest( 'POST', '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( 'POST', '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setRemoteAddress( '10.100.10.1' );
 		$request->setRemotePort( 8599 );
 		$request->setServerSoftware( 'unit/test' );
@@ -185,7 +184,7 @@ final class AbstractRequestTest extends TestCase
 	 */
 	public function testCanResetCustomVars() : void
 	{
-		$request = $this->getRequest( 'POST', '/path/to/script.php', 'Unit-Test' );
+		$request = $this->getRequest( 'POST', '/path/to/script.php', new UrlEncodedFormData(['test' => 'unit']) );
 		$request->setCustomVar( 'UNIT', 'Test' );
 
 		self::assertSame( ['UNIT' => 'Test'], $request->getCustomVars() );

--- a/tests/Unit/Requests/DeleteRequestTest.php
+++ b/tests/Unit/Requests/DeleteRequestTest.php
@@ -34,7 +34,7 @@ final class DeleteRequestTest extends TestCase
 			]
 		);
 
-		$request = DeleteRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new DeleteRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/DeleteRequestTest.php
+++ b/tests/Unit/Requests/DeleteRequestTest.php
@@ -16,7 +16,7 @@ final class DeleteRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new DeleteRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new DeleteRequest( '/path/to/script.php' );
 
 		self::assertSame( 'DELETE', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/GetRequestTest.php
+++ b/tests/Unit/Requests/GetRequestTest.php
@@ -34,7 +34,7 @@ final class GetRequestTest extends TestCase
 			]
 		);
 
-		$request = GetRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new GetRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/GetRequestTest.php
+++ b/tests/Unit/Requests/GetRequestTest.php
@@ -16,7 +16,7 @@ final class GetRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new GetRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new GetRequest( '/path/to/script.php' );
 
 		self::assertSame( 'GET', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PatchRequestTest.php
+++ b/tests/Unit/Requests/PatchRequestTest.php
@@ -16,7 +16,7 @@ final class PatchRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsGet() : void
 	{
-		$request = new PatchRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PatchRequest( '/path/to/script.php' );
 
 		self::assertSame( 'PATCH', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PatchRequestTest.php
+++ b/tests/Unit/Requests/PatchRequestTest.php
@@ -34,7 +34,7 @@ final class PatchRequestTest extends TestCase
 			]
 		);
 
-		$request = PatchRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PatchRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/PostRequestTest.php
+++ b/tests/Unit/Requests/PostRequestTest.php
@@ -16,7 +16,7 @@ final class PostRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsPost() : void
 	{
-		$request = new PostRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PostRequest( '/path/to/script.php' );
 
 		self::assertSame( 'POST', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PostRequestTest.php
+++ b/tests/Unit/Requests/PostRequestTest.php
@@ -34,7 +34,7 @@ final class PostRequestTest extends TestCase
 			]
 		);
 
-		$request = PostRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PostRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Requests/PutRequestTest.php
+++ b/tests/Unit/Requests/PutRequestTest.php
@@ -16,7 +16,7 @@ final class PutRequestTest extends TestCase
 	 */
 	public function testRequestMethodIsPut() : void
 	{
-		$request = new PutRequest( '/path/to/script.php', 'Unit-Test' );
+		$request = new PutRequest( '/path/to/script.php' );
 
 		self::assertSame( 'PUT', $request->getRequestMethod() );
 	}

--- a/tests/Unit/Requests/PutRequestTest.php
+++ b/tests/Unit/Requests/PutRequestTest.php
@@ -34,7 +34,7 @@ final class PutRequestTest extends TestCase
 			]
 		);
 
-		$request = PutRequest::newWithRequestContent( '/path/to/script.php', $urlEncodedContent );
+		$request = new PutRequest( '/path/to/script.php', $urlEncodedContent );
 
 		self::assertSame( 'application/x-www-form-urlencoded', $request->getContentType() );
 		self::assertSame( 'unit=test&test=unit', $request->getContent() );

--- a/tests/Unit/Sockets/SocketCollectionTest.php
+++ b/tests/Unit/Sockets/SocketCollectionTest.php
@@ -246,9 +246,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$request = new PostRequest(
-			dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php',
-			''
-		);
+			dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php' );
 		$socket->sendRequest( $request );
 
 		/** @noinspection UnusedFunctionResultInspection */
@@ -281,7 +279,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$socket->sendRequest(
-			new PostRequest( '/some/script.php', '' )
+			new PostRequest( '/some/script.php' )
 		);
 
 		self::assertNull( $this->collection->getIdleSocket( $connection ) );
@@ -487,7 +485,7 @@ final class SocketCollectionTest extends TestCase
 		);
 
 		$socket->sendRequest(
-			new PostRequest( '/some/sctipt.php', '' )
+			new PostRequest( '/some/sctipt.php' )
 		);
 
 		self::assertTrue( $this->collection->hasBusySockets() );

--- a/tests/Unit/Sockets/SocketTest.php
+++ b/tests/Unit/Sockets/SocketTest.php
@@ -10,6 +10,7 @@ use hollodotme\FastCGI\Exceptions\ReadFailedException;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
+use hollodotme\FastCGI\RequestContents\UrlEncodedFormData;
 use hollodotme\FastCGI\Requests\PostRequest;
 use hollodotme\FastCGI\SocketConnections\Defaults;
 use hollodotme\FastCGI\SocketConnections\NetworkSocket;
@@ -79,7 +80,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 
 		$socket->sendRequest( $request );
@@ -108,7 +109,7 @@ final class SocketTest extends TestCase
 		$data      = ['test-key' => 'unit'];
 		$request   = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 
 		$socket->collectResource( $resources );
@@ -135,7 +136,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 		$request->addResponseCallbacks(
 			static function ( ProvidesResponseData $response )
@@ -163,7 +164,7 @@ final class SocketTest extends TestCase
 		$data    = ['test-key' => 'unit'];
 		$request = new PostRequest(
 			dirname( __DIR__, 2 ) . '/Integration/Workers/worker.php',
-			http_build_query( $data )
+			new UrlEncodedFormData( $data )
 		);
 		$request->addFailureCallbacks(
 			static function ( Throwable $throwable )
@@ -284,7 +285,7 @@ final class SocketTest extends TestCase
 	public function testIsNotUsableWhenTimedOut() : void
 	{
 		$socket  = $this->getSocket();
-		$content = http_build_query( ['sleep' => 1, 'test-key' => 'unit'] );
+		$content = new UrlEncodedFormData( ['sleep' => 1, 'test-key' => 'unit'] );
 		$request = new PostRequest( dirname( __DIR__, 2 ) . '/Integration/Workers/sleepWorker.php', $content );
 		$socket->sendRequest( $request );
 


### PR DESCRIPTION
Attempted fix for https://github.com/hollodotme/fast-cgi-client/issues/18. Implemented option 3 from [this comment](https://github.com/hollodotme/fast-cgi-client/issues/18#issuecomment-421124734). This timeout now also applies to the multi requests since the `getSocketIdsHavingResponse` has been reworked to simply use `hasResponse` in a loop. This is slower than using stream_select on all resources at the same time, but the only way to accurately determine which sockets have responses.

Tried to figure out a test, but couldn't find way to get a socket/check it's timeout just by having the ID. Should we make a basic `getSocketById` method publicly available? Or `$client->sockets->getById`?
